### PR TITLE
Set default log level to 0.

### DIFF
--- a/plugin/log_assert.py
+++ b/plugin/log_assert.py
@@ -176,7 +176,7 @@ def pytest_runtest_makereport(item, call):
 
 def get_logger(*args, **kwargs):
     if 'verbose_lvl' not in kwargs:
-        kwargs['verbose_lvl'] = 2
+        kwargs['verbose_lvl'] = 0
     return mrglog.get_logger(*args, **kwargs)
 
 


### PR DESCRIPTION
This is required for printing summary of test results and other usefull information. This fixes incorrectly set value in commit d3b70f1728.

```
[09:08:08,438] =======================================================================================
[09:08:08,438] Test-case[s] Summary: (3 found)
[09:08:08,439] ---------------------------------------------------------------------------------------
[09:08:08,439] PASS cluster import                          :  #tests:5     #fails:0     desc.:""
[09:08:08,439] PASS create volume                           :  #tests:4     #fails:0     desc.:""
[09:08:08,439] PASS delete volume                           :  #tests:4     #fails:0     desc.:""
[09:08:08,439] =======================================================================================
[09:08:08,439] List of known issues:
[09:08:08,440] ---------------------------------------------------------------------------------------
[09:08:08,440] =======================================================================================
[09:08:08,440] =======================================================================================
[09:08:08,440] Test-Cases Summary   #TOTAL: 3     #PASSED: 3     #FAILED: 0     #ERRORS: 0
[09:08:08,440] Test Summary : ERROR #TOTAl: 13    #PASSED: 13    #FAILED: 0     #ERRORS: 0   #WAIVES: 0
[09:08:08,441] Test name    : jenkins/workspace/3-dahorak-usm2-cluster-test/usmqe-tests
[09:08:08,441] Duration     : 0:00:13.591856
[09:08:08,441] Test on      : Red Hat Enterprise Linux Server release 7.2 (Maipo) x86_64
[09:08:08,441] =======================================================================================
[09:08:08,441] =======================================================================================
[09:08:08,442] Test finished: 09:08:08,438301
```
