### PR TITLE
Update docs, including description of current ansible role guidelines for tendrl components

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,8 +24,8 @@ Contents
    usmqe_team.rst
    repository_overview.rst
    qe_server_setup.rst
-   test_configuration.rst
    test_env_setup.rst
+   test_configuration.rst
    test_execution.rst
    test_development.rst
 
@@ -49,7 +49,7 @@ USM QE tests are:
   plugins
 * written in `Python 3.5`_ only
 * expected to be executed from Red Hat (or CentOS) 7 machine
-* maintained by USM QE Team
+* maintained by :ref:`usmqe-team-label`
 
 There are 2 kind of test cases:
 

--- a/docs/qe_server_setup.rst
+++ b/docs/qe_server_setup.rst
@@ -24,8 +24,8 @@ qe machines.
 Quick Example of QE Server deployment
 =====================================
 
-You need a RHEL or CentOS 7 machine for the QE Server. For to purpose of this
-example, we are going to quickly create virtual machine one via `virt-builder`_
+You need a RHEL 7 or CentOS 7 machine for the QE Server. For the purpose of this
+example, we are going to quickly create one virtual machine via `virt-builder`_
 tool.
 
 First we build a vm image (uploading ssh authorized keys like this would make
@@ -36,7 +36,7 @@ this command):
 
     $ virt-builder centos-7.2 -o mbukatov-qe-server.qcow2 --size 15G --format qcow2 --mkdir /root/.ssh  --chmod 0700:/root/.ssh  --upload /root/.ssh/authorized_keys:/root/.ssh/authorized_keys --selinux-relabel --update
 
-Then we `import the new image into libvirt`_, creating new virtual machine (aka
+Then we `import the new image into libvirt`_ creating new virtual machine (aka
 guest) and  booting it for the first time:
 
 .. code-block:: console

--- a/docs/qe_server_setup.rst
+++ b/docs/qe_server_setup.rst
@@ -24,8 +24,9 @@ qe machines.
 Quick Example of QE Server deployment
 =====================================
 
-You need a CentOS 7 machine for the QE Server. We are going to quickly create 
-one via `virt-builder`_ tool.
+You need a RHEL or CentOS 7 machine for the QE Server. For to purpose of this
+example, we are going to quickly create virtual machine one via `virt-builder`_
+tool.
 
 First we build a vm image (uploading ssh authorized keys like this would make
 the machine accessible for everyone who has keys on the machine you are running
@@ -33,14 +34,14 @@ this command):
 
 .. code-block:: console
 
-    $ virt-builder centos-7.2 -o qe-server.qcow2 --size 15G --format qcow2 --mkdir /root/.ssh  --chmod 0700:/root/.ssh  --upload /root/.ssh/authorized_keys:/root/.ssh/authorized_keys --selinux-relabel --update
+    $ virt-builder centos-7.2 -o mbukatov-qe-server.qcow2 --size 15G --format qcow2 --mkdir /root/.ssh  --chmod 0700:/root/.ssh  --upload /root/.ssh/authorized_keys:/root/.ssh/authorized_keys --selinux-relabel --update
 
-Then we import the new image into libvirt, booting the new virtual machine for
-the first time:
+Then we `import the new image into libvirt`_, creating new virtual machine (aka
+guest) and  booting it for the first time:
 
 .. code-block:: console
 
-    # virt-install --import --name mbukatov-qe-server --ram 2048 --os-variant rhel7 --disk path=/var/lib/libvirt/images/qe-server.qcow2,format=qcow2 --network default --noautoconsole
+    # virt-install --import --name mbukatov-qe-server --ram 2048 --os-variant rhel7 --disk path=/var/lib/libvirt/images/mbukatov-qe-server.qcow2,format=qcow2 --network default --noautoconsole
 
 When the new machine is ready, specify an ip address or fqdn of the new qe
 server in the inventory file:
@@ -127,5 +128,6 @@ For full description and examples how to run integration tests, see
 
 
 .. _`virt-builder`: http://libguestfs.org/virt-builder.1.html
+.. _`import the new image into libvirt`: https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Virtualization_Deployment_and_Administration_Guide/sect-Guest_virtual_machine_installation_overview-Creating_guests_with_virt_install.html
 .. _`qe_server.yml`: https://github.com/Tendrl/usmqe-setup/blob/master/qe_server.yml
 .. _`usmqe-setup repository`: https://github.com/Tendrl/usmqe-setup

--- a/docs/qe_server_setup.rst
+++ b/docs/qe_server_setup.rst
@@ -110,10 +110,20 @@ uses explicit shebang:
     [usmqe@qeserver ~]$ head -1 /usr/bin/ansible
     #!/usr/bin/python2
 
-The last step is to go into `~/usmqe-tests` directory and configure the pytest
-there (see `conf` directory for examples). Then to run the integration tests,
-one runs `py.test` there. TODO: link to other files (both topics deserves a
-separate document with description and full example).
+
+Related information
+===================
+
+At this point, we have a fresh QE server machine. But for us to be able to run
+integration tests, we need to:
+
+* Prepare fresh machines where Tendrl, Ceph and/or Gluster will be installed.
+  See :ref:`test-enviroment-label`.
+* Configure the tests, go into ``~/usmqe-tests`` directory and
+  follow :ref:`config-before-testrun-label`
+
+For full description and examples how to run integration tests, see
+:ref:`test-execution-label`.
 
 
 .. _`virt-builder`: http://libguestfs.org/virt-builder.1.html

--- a/docs/repository_overview.rst
+++ b/docs/repository_overview.rst
@@ -10,10 +10,11 @@ usmqe-tests
 
 Upstream: https://github.com/Tendrl/usmqe-tests
 
-This is a main repository, there are the following top level directories:
+This repository is most important, because it contains python code of automated
+integration test cases. There are the following top level directories:
 
-* ``docs``: documentation (sphinx) of usmqe integration tests and it's setup
-  (you are reading it right now)
+* ``docs``: sphinx based documentation of usmqe integration tests and it's
+  setup (you are reading it right now)
 * ``conf``: configuration files, only examples are commited in the repository
 * ``plugin``: custom pytest plugins
 * ``usmqe``: main usmqe python module

--- a/docs/test_configuration.rst
+++ b/docs/test_configuration.rst
@@ -92,7 +92,7 @@ Now, you need to:
 * Provide all mandatory options in *usm config file* initialized in a previous
   step. This includes: ``username``, ``password``, ``web_url`` and ``api_url``.
   The actual list depends on the test suite you are going to run (eg. api
-  tests doesn't care about ``web_url`` while LDAP integration tests would need
+  tests don't care about ``web_url`` while LDAP integration tests would need
   to know address of the LDAP server).
 
 

--- a/docs/test_configuration.rst
+++ b/docs/test_configuration.rst
@@ -51,6 +51,9 @@ Details for Test Development
 To learn how to access configuration values from code of a test case, see
 :ref:`config-devel-label` for more details.
 
+
+.. _config-before-testrun-label:
+
 Configuration before test run
 =============================
 

--- a/docs/test_configuration.rst
+++ b/docs/test_configuration.rst
@@ -48,35 +48,8 @@ scheme:
 Details for Test Development
 ============================
 
-To access data from the host inventory, use functions provided by
-``usmqe.inventory`` module:
-
-.. code-block:: python
-
-    import usmqe.inventory as inventory
-
-    for host in inventory.role2hosts("ceph_osd"):
-        print("check storage server {0}".format(host))
-
-To access USM QE configuration, use standard pytest configuration functions:
-
-.. code-block:: python
-
-    import pytest
-
-    pytest.config.getini("usm_username")
-
-Obviously this assumes that the ``usm_username`` option has been specified in
-USM QE config file (which is referenced via ``usm_config`` option). The minimal
-ini file for the previous example to work would look like this::
-
-    [usmqepytest]
-    usm_username = admin
-
-Reading of both *USM QE config file* and *host inventory file* is implemented
-in ``plugin/usmqe_config.py`` module, while management of *host inventory file*
-is handled by ``usmqe/inventory.py`` module.
-
+To learn how to access configuration values from code of a test case, see
+:ref:`config-devel-label` for more details.
 
 Configuration before test run
 =============================

--- a/docs/test_development.rst
+++ b/docs/test_development.rst
@@ -20,6 +20,41 @@ rule if readability is affected, assuming the line length doesn't go over
 100 characters (the hard limit).
 
 
+.. _config-devel-label:
+
+Reading Configuration Values
+============================
+
+To access data from the host inventory, use functions provided by
+``usmqe.inventory`` module:
+
+.. code-block:: python
+
+    import usmqe.inventory as inventory
+
+    for host in inventory.role2hosts("ceph_osd"):
+        print("check storage server {0}".format(host))
+
+To access USM QE configuration, use standard pytest configuration functions:
+
+.. code-block:: python
+
+    import pytest
+
+    pytest.config.getini("usm_username")
+
+Obviously this assumes that the ``usm_username`` option has been specified in
+USM QE config file (which is referenced via ``usm_config`` option). The minimal
+ini file for the previous example to work would look like this::
+
+    [usmqepytest]
+    usm_username = admin
+
+Reading of both *USM QE config file* and *host inventory file* is implemented
+in ``plugin/usmqe_config.py`` module, while management of *host inventory file*
+is handled by ``usmqe/inventory.py`` module.
+
+
 .. _unit-tests-label:
 
 Unit Tests

--- a/docs/test_env_setup.rst
+++ b/docs/test_env_setup.rst
@@ -91,6 +91,37 @@ tasks directly.
 Details On Installation From Sources
 ====================================
 
+To install Tendrl component from source code, we clone git source repository
+into ``/opt/tendrl/${component_name}`` first.
+
+Here is an example from ``tendrl-common`` role, default values of related
+variables::
+
+    #
+    # variables used when install_from == source
+    #
+
+    # url of the source repository and the branch to checkout
+    tendrl_common_repo_url: 'https://github.com/Tendrl/common'
+    # note that you need to change the branch in the url as well
+    tendrl_common_repo_branch: master
+
+    # directory where the git repo would be cloned into
+    tendrl_common_repo: /opt/tendrl/common
+
+... and related tasks which do the cloning::
+
+    - name: Directory for git repository
+      file:
+        path="{{ tendrl_common_repo }}"
+        state=directory
+
+    - name: Clone git repository
+      git:
+        repo={{ tendrl_common_repo_url }}
+        version={{ tendrl_common_repo_branch }}
+        dest={{ tendrl_common_repo }}
+
 When a Tendrl component is implemented in python, virtualenv is not used, but
 tendrl python components are installed into the system site-packages. Since
 such operation breaks system consistency, this is another reason why this

--- a/docs/test_env_setup.rst
+++ b/docs/test_env_setup.rst
@@ -1,3 +1,5 @@
+.. _test-enviroment-label:
+
 ==========================
  Setup of Test Enviroment
 ==========================

--- a/docs/test_env_setup.rst
+++ b/docs/test_env_setup.rst
@@ -17,5 +17,116 @@ For this reason, all post installation and test setup configuration steps
 are automated via ansible playbooks and stored in a separate `usmqe-setup
 repository`_. You need to deploy test machines using playbooks from there.
 
+
+Ansible Roles for Tendrl Setup
+==============================
+
+Right now, we maintain ansible roles and playbook which automates production
+like installation of all Tendrl components. `Tendrl project wide
+documentation`_ is followed, but most details are based on documentation or
+README files of each component.
+
+For each Tendrl component, there is a role in `usmqe-setup repository`_. For
+example, there are:
+
+* `tendrl-common`_
+* `tendrl-node-agent`_
+* `tendrl-api`_
+
+Note: the list presented doesn't include all roles. You would need to check
+``roles`` directory in the repository to see current full list of roles.
+
+Every ansible role of particular tendrl component has the following tasks
+structure::
+
+    tasks/
+    ├── binary.yml
+    ├── main.yml
+    └── source.ym
+
+Where ``main.yml`` looks like this (the example comes from ``tendrl-common``)::
+
+    #
+    # installation
+    #
+    
+    - include: source.yml
+      when: install_from == "source"
+    
+    - include: binary.yml
+      when: install_from == "packages"
+    
+    #
+    # post installation configuration
+    #
+    
+    - name: Specify etcd_connection in tendrl.conf
+      ini_file:
+        dest=/etc/tendrl/tendrl.conf
+        section=common
+        option=etcd_connection
+        value="{{ groups['usm_server'][0] }}"
+
+As you can see, there are 2 additional yaml files, one for installation from
+rpm packages and other for installation from source code. The default value of
+``install_from`` variable should be set to ``packages`` in ``defaults`` of each
+role. File ``source.yml`` should provide feature parity with rpm package based
+installation, so that the common configuration steps are icluded in ``main.yml``
+file directly - as *etcd_connection in tendrl.conf* is in this case.
+
+Package (rpm) base installation has priority and should always work. Actual
+testing of a Tendrl release should be done with packages only.
+
+Source based installation is provided as a convenience so that qe team
+can work with latest and greatest code to develop new test cases or check
+particular unfinished new feature. It should not be used for CI test runs or
+to validate that given feature or bug is done/fixed. See more details on this
+in section below.
+
+Moreover, related Tendrl documentation (or README files) used to write the role
+should be referenced in the README file of the role or in the yaml file with
+tasks directly.
+
+
+Details On Installation From Sources
+====================================
+
+When a Tendrl component is implemented in python, virtualenv is not used, but
+tendrl python components are installed into the system site-packages. Since
+such operation breaks system consistency, this is another reason why this
+should be used only for test development only.
+
+Virtualenv is very usefull for development and testing of particular
+components, and I still suggest to use it when code changes needs to be checked
+manually immediately during development (and for this reason, it's a good
+thing that virtualenv is suggested in devel installation docs of tendrl
+components), but for installing multiple python packages which needs to run
+under root for the purposes of integration testing, automation of virtualenv
+based installation is not maintenable (most ansible modules doesn't consider
+this use case and additional setup would be still needed).
+
+When source based installation is not feature complete (doesn't provide the
+same level of setup as expected from package based installation), it's
+necessary to include assert like this in the end of yaml file to make this
+clear::
+
+    - fail: msg="There is no systemd unit installed, we can't start and enable it"
+      when: not ignore_incomplete_installation
+
+One can still use such role, but would need to set
+``ignore_incomplete_installation`` to ``true`` in the playbook. That said, in
+most cases, a workaround implementing missing feature would be needed for the
+role to be actually useful. For the previous example, we have `added a task to
+install systemd unit files`_.
+
+The last but not least: maintenance of source based installation like this has
+it's cost and we may drop this entirely in the future.
+
+
 .. _`qe_server.yml`: https://github.com/Tendrl/usmqe-setup/blob/master/qe_server.yml
 .. _`usmqe-setup repository`: https://github.com/Tendrl/usmqe-setup
+.. _`tendrl-common`: https://github.com/Tendrl/usmqe-setup/tree/master/roles/tendrl-common
+.. _`tendrl-node-agent`: https://github.com/Tendrl/usmqe-setup/tree/master/roles/tendrl-node-agent
+.. _`tendrl-api`: https://github.com/Tendrl/usmqe-setup/tree/master/roles/tendrl-api
+.. _`added a task to install systemd unit files`: https://github.com/Tendrl/usmqe-setup/commit/75f489d850ea753582cfa8532957c2a9d153d186
+.. _`Tendrl project wide documentation`: https://github.com/Tendrl/documentation/blob/master/deployment.adoc

--- a/docs/test_execution.rst
+++ b/docs/test_execution.rst
@@ -1,8 +1,32 @@
+.. _test-execution-label:
+
 ================
  Test Execution
 ================
 
-USM QE Tests are executed under ``usmqe`` user account on QE Server machine
-(see :ref:`qe-server-label` for more details).
+This document provides description and examples of integration test execution.
 
-TODO: include all the details
+
+Requirements
+============
+
+USM QE Tests are executed under ``usmqe`` user account on QE Server machine,
+so we expect that:
+
+* QE Server machine has beed deployed as described in :ref:`qe-server-label`
+* machines for Tendrl/Ceph/Gluster have beed deployed as described in
+  :ref:`test-enviroment-label`
+* configuration of USM QE tests has been done as explained in
+  :ref:`config-before-testrun-label`
+
+
+How to run the tests
+====================
+
+TODO: add all the details
+
+
+Examples
+========
+
+TODO: provide few examples

--- a/docs/usmqe_team.rst
+++ b/docs/usmqe_team.rst
@@ -7,7 +7,7 @@ The USM QE Team members are (in alphabetical order):
 * Daniel Horák (`github.com/dahorak`_)
 * Filip Balák (`github.com/fbalak`_)
 * Luboš Tříletý (`github.com/ltrilety`_)
-* Martin Bukatovič (`gitlab.com/u/mbukatov`_, `github.com/mbukatov`_)
+* Martin Bukatovič (`gitlab.com/mbukatov`_, `github.com/mbukatov`_)
 * Martin Kudlej (`github.com/mkudlej`_)
 
 
@@ -16,4 +16,4 @@ The USM QE Team members are (in alphabetical order):
 .. _`github.com/ltrilety`: https://github.com/ltrilety
 .. _`github.com/mbukatov`: https://github.com/mbukatov
 .. _`github.com/mkudlej`: https://github.com/mkudlej
-.. _`gitlab.com/u/mbukatov`: https://gitlab.com/u/mbukatov
+.. _`gitlab.com/mbukatov`: https://gitlab.com/mbukatov

--- a/docs/usmqe_team.rst
+++ b/docs/usmqe_team.rst
@@ -1,3 +1,5 @@
+.. _usmqe-team-label:
+
 =============
  USM QE Team
 =============


### PR DESCRIPTION
This updates rst files in `docs/` directory only.

Changes include linking of related documents and description of ansible role guidelines for tendrl components.