### PR TITLE
Change usm_host_config parameter to usm_inventory

### DIFF
--- a/docs/test_configuration.rst
+++ b/docs/test_configuration.rst
@@ -19,7 +19,7 @@ scheme:
   normal circumstances (configuring ``usmqe-tests`` before test run) one would
   not need to change this file at all, because any default value specified here
   can be reconfigured in USM QE config file (with the exception of
-  ``usm_config`` and ``usm_host_config`` options).
+  ``usm_config`` and ``usm_inventory`` options).
 
 * *USM QE config file* is expected to contain actual configuration. See an
   example in `conf/example_usm.ini`_, while the actual path of this file is
@@ -31,7 +31,7 @@ scheme:
 * Ansible *host inventory file* (see an example in ``conf/example.hosts``),
   which is used both by ansible and by USM QE inventory module to organize
   machines into groups by it's role in test cluster. Actual path of this file
-  is configured in ``usm_host_config`` option in main ``pytest.ini`` file.
+  is configured in ``usm_inventory`` option in main ``pytest.ini`` file.
 
 * Moreover ad hoc reconfiguration of any USM QE option is possible via pytest
   command line option ``--override-ini``. See an example how to use different
@@ -39,7 +39,7 @@ scheme:
 
   .. code-block:: console
 
-      $ py.test -o=usm_host_config=conf/mbukatov01.hosts usmqe_tests/foo/bar
+      $ py.test -o=usm_inventory=conf/mbukatov01.hosts usmqe_tests/foo/bar
 
   This is usefull for test runs started by hand during test development or
   debugging.
@@ -76,7 +76,7 @@ Now, you need to:
   cluster.
 
 * Store *host inventory file* in ``conf/clustername.hosts`` and specify this
-  path in ``usm_host_config`` option of ``pytest.ini``.
+  path in ``usm_inventory`` option of ``pytest.ini``.
 
 * Verify that ssh and ansible are configured so that one can reach all machines
   from test cluster:

--- a/plugin/usmqe_config.py
+++ b/plugin/usmqe_config.py
@@ -19,7 +19,7 @@ def pytest_addoption(parser):
     """
     # defaults are specified in root pytest.ini file
     parser.addini('usm_config', 'USM configuration')
-    parser.addini('usm_host_config', 'USM host configuration')
+    parser.addini('usm_inventory', 'USM host configuration')
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -29,13 +29,13 @@ def load_inventory():
 
     To use content from inventory file just *import inventory* and then use
     proper function from ``usmqe.inventory``.
-    Name of inventory file is stored in ``usm_host_config`` option in
+    Name of inventory file is stored in ``usm_inventory`` option in
     ``pytest.ini``.  Its value can be overriden by ``pytest -o
-    usm_host_config=path``.
+    usm_inventory=path``.
     """
     # update machine config (reading ansible inventory)
     hosts = ConfigParser(allow_no_value=True)
-    hosts.read(pytest.config.getini("usm_host_config"))
+    hosts.read(pytest.config.getini("usm_inventory"))
     for rolename in hosts.sections():
         for hostname, _ in hosts.items(rolename):
             usmqe.inventory.add_host_entry(rolename, hostname)

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,7 +14,7 @@ usm_config = conf/usm.ini
 
 # Path to the host inventory file (list of all machines of a test cluster
 # grouped into roles). This file is used both by ansible and usm qe tests.
-usm_host_config = conf/usm.hosts
+usm_inventory = conf/usm.hosts
 
 # Predefined usmqe configuration values.
 # You should not change them here, but edit ini file referenced in usm_config


### PR DESCRIPTION
    change the parameter name so both usm_config and usm_inventory has the same number of words
    better to read
    following command was used
    sed -i 's/usm_host_config/usm_inventory/g' docs/test_configuration.rst plugin/usmqe_config.py pytest.ini