### PR TITLE
requirements.txt: add selenium 2.53.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,8 @@ pytest-ansible-playbook
 plumbum
 requests
 mrglog
+
+# we have to use selenium compatible with firefox packaged in RHEL/CentOS 7
+# see https://stackoverflow.com/questions/40048940
+# see also: https://www.python.org/dev/peps/pep-0440/#version-specifiers
+selenium == 2.53.6


### PR DESCRIPTION
We need to use last stable 2.x release of selenium, because newer
versions are not compatible with firefox packaged in RHEL/CentOS 7.

See: https://stackoverflow.com/questions/40048940/geckodriver-executable-needs-to-be-in-path