### PR TITLE
remove workaround for unpublished webstr module

### DIFF
--- a/usmqe/unit_tests/test_import_all.py
+++ b/usmqe/unit_tests/test_import_all.py
@@ -26,11 +26,4 @@ def test_import(module):
     """
     Just try to import given module.
     """
-    try:
-        importlib.import_module(module)
-    # TODO: FIXME Remove try except block when webstr will be public
-    except ImportError as exc:
-        if 'webstr' not in str(exc):
-            raise exc
-        else:
-            pytest.xfail(reason=str(exc))
+    importlib.import_module(module)


### PR DESCRIPTION
This commit removes workaround introduced in following pull request:
https://github.com/Tendrl/usmqe-tests/pull/36/files