### PR TITLE
Update auth api tests

### DIFF
--- a/usmqe/api/tendrlapi/common.py
+++ b/usmqe/api/tendrlapi/common.py
@@ -176,7 +176,12 @@ class TendrlApi(ApiBase):
         return response.json()
 
     def flows(self, asserts_in=None):
-        """ Ping REST API
+        """
+        Provides list of flows which can be performed either globally or on a
+        specific resource.
+
+        See: https://github.com/Tendrl/api/blob/master/docs/overview.adoc#flows
+
         Name:        "flows",
         Method:      "GET",
         Pattern:     "Flows",

--- a/usmqe/api/tendrlapi/common.py
+++ b/usmqe/api/tendrlapi/common.py
@@ -174,3 +174,18 @@ class TendrlApi(ApiBase):
         self.print_req_info(response)
         self.check_response(response, asserts_in)
         return response.json()
+
+    def flows(self, asserts_in=None):
+        """ Ping REST API
+        Name:        "flows",
+        Method:      "GET",
+        Pattern:     "flows",
+        """
+        pattern = "flows"
+        response = requests.get(
+            pytest.config.getini("usm_api_url") + pattern,
+            auth=self._auth,)
+        self.print_req_info(response)
+        self.check_response(response, asserts_in)
+        # TODO: some minimal validation of flows response?
+        return response.json()

--- a/usmqe/api/tendrlapi/common.py
+++ b/usmqe/api/tendrlapi/common.py
@@ -179,9 +179,9 @@ class TendrlApi(ApiBase):
         """ Ping REST API
         Name:        "flows",
         Method:      "GET",
-        Pattern:     "flows",
+        Pattern:     "Flows",
         """
-        pattern = "flows"
+        pattern = "Flows"
         response = requests.get(
             pytest.config.getini("usm_api_url") + pattern,
             auth=self._auth,)

--- a/usmqe_tests/api/others/test_authentication.py
+++ b/usmqe_tests/api/others/test_authentication.py
@@ -8,7 +8,7 @@ from usmqe.api.tendrlapi.common import TendrlApi, login, logout
 
 def test_login_valid(valid_session_credentials):
     api = TendrlApi(auth=valid_session_credentials)
-    api.ping()
+    api.flows()
 
 
 def test_login_invalid():
@@ -20,7 +20,7 @@ def test_login_invalid():
         }
     auth = login("invalid_user", "invalid_password", asserts_in=asserts)
     api = TendrlApi(auth)
-    api.ping(asserts_in=asserts)
+    api.flows(asserts_in=asserts)
 
 
 def test_session_unauthorized():
@@ -33,7 +33,7 @@ def test_session_unauthorized():
     # passing auth=None would result in api requests to be done without Tendrl
     # auth header
     api = TendrlApi(auth=None)
-    api.ping(asserts_in=asserts)
+    api.flows(asserts_in=asserts)
 
 
 def test_session_invalid(invalid_session_credentials):
@@ -44,7 +44,7 @@ def test_session_invalid(invalid_session_credentials):
         "status": 401,
         }
     api = TendrlApi(auth=invalid_session_credentials)
-    api.ping(asserts_in=asserts)
+    api.flows(asserts_in=asserts)
 
 
 # TODO: find out why xfail doesn't work here
@@ -75,11 +75,11 @@ def test_login_multiple_sessions_twisted():
     api_two = TendrlApi(auth=login(
         pytest.config.getini("usm_username"),
         pytest.config.getini("usm_password")))
-    api_one.ping()
-    api_two.ping()
+    api_one.flows()
+    api_two.flows()
     logout(auth=api_one._auth)
-    api_one.ping(asserts_in=asserts)
-    api_two.ping()
+    api_one.flows(asserts_in=asserts)
+    api_two.flows()
     logout(auth=api_two._auth)
-    api_one.ping(asserts_in=asserts)
-    api_two.ping(asserts_in=asserts)
+    api_one.flows(asserts_in=asserts)
+    api_two.flows(asserts_in=asserts)

--- a/usmqe_tests/api/others/test_authentication.py
+++ b/usmqe_tests/api/others/test_authentication.py
@@ -47,8 +47,6 @@ def test_session_invalid(invalid_session_credentials):
     api.flows(asserts_in=asserts)
 
 
-# TODO: find out why xfail doesn't work here
-@pytest.mark.xfail(reason='https://github.com/Tendrl/api/issues/118')
 def test_login_multiple_sessions():
     auth_one = login(
         pytest.config.getini("usm_username"),
@@ -60,8 +58,6 @@ def test_login_multiple_sessions():
     logout(auth=auth_two)
 
 
-# TODO: find out why xfail doesn't work here
-@pytest.mark.xfail(reason='https://github.com/Tendrl/api/issues/118')
 def test_login_multiple_sessions_twisted():
     asserts = {
         "cookies": None,

--- a/usmqe_tests/api/others/test_ping.py
+++ b/usmqe_tests/api/others/test_ping.py
@@ -15,7 +15,7 @@ Teardown
 """
 
 
-def test_ping(valid_session_credentials):
+def test_ping():
     """@pylatest api/ping
     API: ping
     **********************
@@ -27,7 +27,7 @@ def test_ping(valid_session_credentials):
 
     Positive ping test.
     """
-    test = TendrlApi(auth=valid_session_credentials)
+    test = TendrlApi()
     # TODO(fbalak): add valid returned json to docstring and test them
     """@pylatest api/common.ping_valid
     .. test_step:: 1


### PR DESCRIPTION
Since ping call no longer requires authentication, this commit removes
valid_session_credentials fixture from ping test and replaces ping with
flows call in authentication tests.

Resolves https://github.com/Tendrl/usmqe-tests/issues/70