### PR TITLE
Check all rpm packages from deps repo and enable check-upgrade

### DIFF
--- a/usmqe_tests/rpm/conftest.py
+++ b/usmqe_tests/rpm/conftest.py
@@ -11,6 +11,8 @@ import pytest
 import requests
 import subprocess
 
+from packagelist import tendrl_packages
+
 
 @pytest.fixture(scope="module")
 def chroot_dir(tendrl_repos):
@@ -189,18 +191,9 @@ def list_tendrl_deps_packages():
     return result
 
 
-@pytest.fixture(scope="module", params=[
-    "tendrl-alerting",
-    "tendrl-api",
-    "tendrl-api-httpd",
-    "tendrl-ceph-integration",
-    "tendrl-commons",
-    "tendrl-dashboard",
-    "tendrl-gluster-integration",
-    "tendrl-node-agent",
-    "tendrl-node-monitoring",
-    "tendrl-performance-monitoring",
-    ] + list_tendrl_deps_packages())
+@pytest.fixture(
+    scope="module",
+    params=tendrl_packages + list_tendrl_deps_packages())
 def rpm_package(request, tendrl_repos):
     """
     Fixture downloads given rpm package from given repository

--- a/usmqe_tests/rpm/conftest.py
+++ b/usmqe_tests/rpm/conftest.py
@@ -171,24 +171,25 @@ def list_tendrl_deps_packages():
     This helper function returns list of all rpm packages in tendrl deps
     repository.
     """
-    result = [
-        "ansible",
-        "gstatus",
-        "hwinfo",
-        "libx86emu1",
-        "python-etcd",
-        "python-gdeploy",
-        "python-maps",
-        "python-ruamel-yaml",
-        "rubygem-bundler",
-        "rubygem-etcd",
-        "rubygem-minitest",
-        "rubygem-mixlib-log",
-        "rubygem-puma",
-        "rubygem-sinatra",
-        "rubygem-tilt",
+    # try to get baseurl of tendrl-deps repository (calling a fixture directly
+    # like that is a HACK, but it avoids code duplication and the test # case
+    # uses the very same fixture anway, so the consequences should not be that
+    # terrible ...)
+    baseurl = tendrl_repos().get('tendrl-deps')
+    # if tendrl-deps repo is not defined, we don't check deps packages at all
+    if baseurl is None:
+        return []
+    # list all package names from given repo
+    cmd = [
+        "repoquery",
+        "--repofrompath='tendrl-deps,{}'".format(baseurl),
+        "--repoid=tendrl-deps",
+        "--all",
+        "--qf='%{name}'",
         ]
-    return result
+    stdout = subprocess.check_output(cmd)
+    rpm_name_list = stdout.split("\n")
+    return rpm_name_list
 
 
 @pytest.fixture(

--- a/usmqe_tests/rpm/conftest.py
+++ b/usmqe_tests/rpm/conftest.py
@@ -164,21 +164,31 @@ def tendrl_repos():
     return repo_dict
 
 
+def list_tendrl_deps_packages():
+    """
+    This helper function returns list of all rpm packages in tendrl deps
+    repository.
+    """
+    result = [
+        "gstatus",
+        "hwinfo",
+        "libx86emu1",
+        "python-etcd",
+        "python-gdeploy",
+        "python-maps",
+        "python-ruamel-yaml",
+        "rubygem-bundler",
+        "rubygem-etcd",
+        "rubygem-minitest",
+        "rubygem-mixlib-log",
+        "rubygem-puma",
+        "rubygem-sinatra",
+        "rubygem-tilt",
+        ]
+    return result
+
+
 @pytest.fixture(scope="module", params=[
-    "gstatus",
-    "hwinfo",
-    "libx86emu1",
-    "python-etcd",
-    "python-gdeploy",
-    "python-maps",
-    "python-ruamel-yaml",
-    "rubygem-bundler",
-    "rubygem-etcd",
-    "rubygem-minitest",
-    "rubygem-mixlib-log",
-    "rubygem-puma",
-    "rubygem-sinatra",
-    "rubygem-tilt",
     "tendrl-alerting",
     "tendrl-api",
     "tendrl-api-httpd",
@@ -189,7 +199,7 @@ def tendrl_repos():
     "tendrl-node-agent",
     "tendrl-node-monitoring",
     "tendrl-performance-monitoring",
-    ])
+    ] + list_tendrl_deps_packages())
 def rpm_package(request, tendrl_repos):
     """
     Fixture downloads given rpm package from given repository

--- a/usmqe_tests/rpm/conftest.py
+++ b/usmqe_tests/rpm/conftest.py
@@ -170,6 +170,7 @@ def list_tendrl_deps_packages():
     repository.
     """
     result = [
+        "ansible",
         "gstatus",
         "hwinfo",
         "libx86emu1",

--- a/usmqe_tests/rpm/packagelist.py
+++ b/usmqe_tests/rpm/packagelist.py
@@ -1,0 +1,14 @@
+# -*- coding: utf8 -*-
+
+tendrl_packages = [
+    "tendrl-alerting",
+    "tendrl-api",
+    "tendrl-api-httpd",
+    "tendrl-ceph-integration",
+    "tendrl-commons",
+    "tendrl-dashboard",
+    "tendrl-gluster-integration",
+    "tendrl-node-agent",
+    "tendrl-node-monitoring",
+    "tendrl-performance-monitoring",
+    ]

--- a/usmqe_tests/rpm/packagelist.py
+++ b/usmqe_tests/rpm/packagelist.py
@@ -1,5 +1,10 @@
 # -*- coding: utf8 -*-
 
+import configparser
+import subprocess
+
+
+# list of all tendrl packages
 tendrl_packages = [
     "tendrl-alerting",
     "tendrl-api",
@@ -12,3 +17,53 @@ tendrl_packages = [
     "tendrl-node-monitoring",
     "tendrl-performance-monitoring",
     ]
+
+
+# name of usmqe config option (as in usm.ini file) for given tendrl reponame
+reponame2gpgkey_confname = {
+    "tendrl-core": "usm_core_gpgkey_url",
+    "tendrl-deps": "usm_deps_gpgkey_url",
+    }
+reponame2baseurl_confname = {
+    "tendrl-core": "usm_core_baseurl",
+    "tendrl-deps": "usm_deps_baseurl",
+    }
+
+
+def list_packages(reponame):
+    """
+    This helper function returns list of all rpm packages in given repository.
+    """
+    # try to get baseurl of repository directly from usmqe config file,
+    # which is even more TERRIBLE HACK, but I can't help it as pytest.config is
+    # not available during of fixture arguments ...
+    # TODO: we may want to reconsider design of usmqe configuration
+    pytest_ini = configparser.ConfigParser()
+    pytest_ini.read_file(open("pytest.ini"))
+    usm_config_path = pytest_ini.get("pytest", "usm_config")
+    usm_config = configparser.ConfigParser()
+    usm_config.read_file(open(usm_config_path))
+    # if repo is not defined in config file, we have no packages to check ...
+    if (
+            "usmqepytest" in usm_config and
+            reponame2baseurl_confname[reponame] in usm_config["usmqepytest"]
+            ):
+        baseurl = usm_config.get(
+            "usmqepytest",
+            reponame2baseurl_confname[reponame])
+    else:
+        return []
+    # list all package names from given repo
+    cmd = [
+        "repoquery",
+        "--repofrompath={},{}".format(reponame, baseurl),
+        "--repoid={}".format(reponame),
+        "--all",
+        "--qf='%{name}'",
+        ]
+    stdout = subprocess.check_output(cmd)
+    rpm_name_list = stdout.decode('utf-8').replace("'", "").split("\n")
+    # account for edge case of stdout2list conversion
+    if len(rpm_name_list) >= 1 and len(rpm_name_list[-1]) == 0:
+        rpm_name_list.pop()
+    return rpm_name_list

--- a/usmqe_tests/rpm/packagelist.py
+++ b/usmqe_tests/rpm/packagelist.py
@@ -8,6 +8,7 @@ import subprocess
 tendrl_packages = [
     "tendrl-alerting",
     "tendrl-api",
+    "tendrl-api-doc",
     "tendrl-api-httpd",
     "tendrl-ceph-integration",
     "tendrl-commons",

--- a/usmqe_tests/rpm/test_install.py
+++ b/usmqe_tests/rpm/test_install.py
@@ -3,22 +3,13 @@
 import pytest
 import subprocess
 
+from packagelist import tendrl_packages
+
 
 LOGGER = pytest.get_logger(__name__, module=True)
 
 
-@pytest.mark.parametrize("rpm_name", [
-    "tendrl-alerting",
-    "tendrl-api",
-    "tendrl-api-httpd",
-    "tendrl-ceph-integration",
-    "tendrl-commons",
-    "tendrl-dashboard",
-    "tendrl-gluster-integration",
-    "tendrl-node-agent",
-    "tendrl-node-monitoring",
-    "tendrl-performance-monitoring",
-    ])
+@pytest.mark.parametrize("rpm_name", tendrl_packages)
 def test_yum_install(chroot_dir, rpm_name):
     """
     Try to install and uninstall rpm package via yum in CentOS 7 chroot.

--- a/usmqe_tests/rpm/test_install.py
+++ b/usmqe_tests/rpm/test_install.py
@@ -3,13 +3,13 @@
 import pytest
 import subprocess
 
-from packagelist import tendrl_packages
+from packagelist import list_packages
 
 
 LOGGER = pytest.get_logger(__name__, module=True)
 
 
-@pytest.mark.parametrize("rpm_name", tendrl_packages)
+@pytest.mark.parametrize("rpm_name", list_packages('tendrl-core'))
 def test_yum_install(chroot_dir, rpm_name):
     """
     Try to install and uninstall rpm package via yum in CentOS 7 chroot.

--- a/usmqe_tests/rpm/test_rpm.py
+++ b/usmqe_tests/rpm/test_rpm.py
@@ -46,9 +46,10 @@ def test_repoclosure(tendrl_repos, centos_repos):
             LOGGER.failed(line.decode())
 
 
-def test_repo(tendrl_repos):
+def test_repo_packagelist(tendrl_repos):
     """
-    Check that tendrl core repository contains all tendrl packages as expected.
+    Check that tendrl core repository contains all expected tendrl packages and
+    doesn't contain anything else.
     """
     LOGGER.info(
         "expected tendrl-core packages are: " + ",".join(tendrl_packages))

--- a/usmqe_tests/rpm/test_rpm.py
+++ b/usmqe_tests/rpm/test_rpm.py
@@ -63,6 +63,7 @@ def test_rpmlint(rpm_package):
 @pytest.mark.parametrize("check_command", [
     "check-sat",
     "check-conflicts",
+    "check-upgrade",
     ])
 def test_rpmdeplint(rpm_package, check_command, tendrl_repos, centos_repos):
     rpm_name, rpm_path = rpm_package

--- a/usmqe_tests/rpm/test_rpm.py
+++ b/usmqe_tests/rpm/test_rpm.py
@@ -1,8 +1,11 @@
 # -*- coding: utf8 -*-
 
-import pytest
 import subprocess
 import tempfile
+
+import pytest
+
+from packagelist import list_packages, tendrl_packages
 
 
 LOGGER = pytest.get_logger(__name__, module=True)
@@ -41,6 +44,25 @@ def test_repoclosure(tendrl_repos, centos_repos):
             LOGGER.failed(line.decode())
         for line in cp.stderr.splitlines():
             LOGGER.failed(line.decode())
+
+
+def test_repo(tendrl_repos):
+    """
+    Check that tendrl core repository contains all tendrl packages as expected.
+    """
+    LOGGER.info(
+        "expected tendrl-core packages are: " + ",".join(tendrl_packages))
+    # get actual list of packages from tendrl-core repository (via repoquery)
+    packages = list_packages('tendrl-core')
+    for rpm_name in tendrl_packages:
+        msg = "package {} should be present in tendrl-core repo"
+        package_present = rpm_name in packages
+        pytest.check(package_present, msg.format(rpm_name))
+        if package_present:
+            packages.remove(rpm_name)
+    pytest.check(packages == [], msg="there should be no extra packages")
+    for rpm_name in packages:
+        LOGGER.failed("unexpected package in tendrl-core: {}".format(rpm_name))
 
 
 def test_rpmlint(rpm_package):


### PR DESCRIPTION
Update rpm tests to check all rpm packages from tendrl-deps and enable rpmdeplint check-upgrade. 

Workaround for reading baseurl of tendrl-deps repo was necessary though - check if you consider the hack good enough :)

This may be adressing https://github.com/Tendrl/usmqe-tests/issues/84 (but needs to be rechecked).