### PR TITLE
fix: replace logger.error with logger.fail call

### DIFF
--- a/usmqe_tests/rpm/test_install.py
+++ b/usmqe_tests/rpm/test_install.py
@@ -22,7 +22,7 @@ def test_yum_install(chroot_dir, rpm_name):
     cp = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     LOGGER.debug("STDOUT: %s", cp.stdout)
     if len(cp.stderr) > 0:
-        LOGGER.error("STDERR: %s", cp.stderr)
+        LOGGER.failed("STDERR: %s", cp.stderr)
     else:
         LOGGER.debug("STDERR: %s", cp.stderr)
     check_msg = "return code of 'yum install {}' should be 0 indicating no errors"

--- a/usmqe_tests/rpm/test_install.py
+++ b/usmqe_tests/rpm/test_install.py
@@ -22,7 +22,7 @@ def test_yum_install(chroot_dir, rpm_name):
     cp = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     LOGGER.debug("STDOUT: %s", cp.stdout)
     if len(cp.stderr) > 0:
-        LOGGER.failed("STDERR: %s", cp.stderr)
+        LOGGER.warning("STDERR: %s", cp.stderr)
     else:
         LOGGER.debug("STDERR: %s", cp.stderr)
     check_msg = "return code of 'yum install {}' should be 0 indicating no errors"


### PR DESCRIPTION
This pull request fixes issue which makes particular type of failure during yum installation test (errors/warnings on stderr during yum install) reported as pass in unit xml export file.

I shouldn't have used `LOGGER.error()` call in test case code to report issues, because ERROR state is used to convey issue with setup/teardown only. I'm fixing this by using `LOGGER.failed()` instead.