### PR TITLE
Pool tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ dist
 *.html
 .cache
 *.ini
+*.hosts
 
 logs

--- a/conf/example_usm.ini
+++ b/conf/example_usm.ini
@@ -12,4 +12,4 @@ usm_api_url = %(usm_web_url):9393/api/1.0/
 etcd_api_url = %(usm_web_url):2379/v2/
 usm_ca_cert = conf/tendrl_ca.crt
 usm_volume_name = TestVolume
-usm_pool_name=PoolName
+usm_pool_name = TestPool

--- a/conf/example_usm.ini
+++ b/conf/example_usm.ini
@@ -7,6 +7,9 @@
 usm_log_level = DEBUG
 usm_username = <username>
 usm_password = <password>
-usm_web_url = https://example-usm3-server.usmqe.tendrl.org
+usm_web_url = http://example-usm3-server.usmqe.tendrl.org
 usm_api_url = %(usm_web_url):9393/api/1.0/
+etcd_api_url = %(usm_web_url):2379/v2/
 usm_ca_cert = conf/tendrl_ca.crt
+usm_volume_name = TestVolume
+usm_pool_name=PoolName

--- a/docs/test_configuration.rst
+++ b/docs/test_configuration.rst
@@ -70,10 +70,9 @@ We assume that:
 
 Now, you need to:
 
-* Check that ``usmqe`` user has a private ssh key in ``~/.ssh/id_rsa`` file 
-  (this is default location of ssh key specified in ``usm_keyfile`` option of
-  ``pytest.ini``) and has it's public ssh key deployed on all machines of test
-  cluster.
+* Check that ``usmqe`` user can ssh to all nodes with his ssh key stored 
+  in ``~/.ssh``. This can be configured in ``~/.ssh/config``.
+  Public ssh key is deployed on all machines of test cluster.
 
 * Store *host inventory file* in ``conf/clustername.hosts`` and specify this
   path in ``usm_inventory`` option of ``pytest.ini``.

--- a/pytest.ini
+++ b/pytest.ini
@@ -30,7 +30,6 @@ usm_password =
 usm_web_url =
 usm_api_url =
 usm_ca_cert = False
-usm_keyfile = "~/.ssh/id_rsa"
 
 # webstr config group: webstr specific options
 usm_webstr_selenium_server =

--- a/usmqe/api/base.py
+++ b/usmqe/api/base.py
@@ -3,8 +3,8 @@
 Basic REST API.
 """
 
-import pytest
 import json
+import pytest
 
 LOGGER = pytest.get_logger("api_base", module=True)
 
@@ -60,7 +60,7 @@ class ApiBase(object):
         try:
             json.dumps(resp.json(encoding='unicode'))
         except ValueError as err:
-            pytest.check(False, "Bad response json format: {}".format(err))
+            pytest.check(False, "Bad response json format: '{}'".format(err))
         pytest.check(
             resp.ok == asserts["ok"],
             "There should be ok == {}".format(str(asserts["ok"])))
@@ -80,7 +80,7 @@ class ApiBase(object):
                   {'name': str, 'size': int, 'tasks': dict}
         """
         LOGGER.debug("check_dict - data: {}".format(data))
-        LOGGER.debug("check_dict - schema: []".format(schema))
+        LOGGER.debug("check_dict - schema: {}".format(schema))
         expected_keys = sorted(schema.keys())
         keys = sorted(data.keys())
         pytest.check(

--- a/usmqe/api/base.py
+++ b/usmqe/api/base.py
@@ -88,8 +88,8 @@ class ApiBase(object):
             "Data should contains keys: {}".format(expected_keys))
         for key in keys:
             pytest.check(key in expected_keys,
-                         "Unknown key '{}' with value '{}' (type: '{}').\
-                         ".format(key, data[key], type(data[key])))
+                         "Unknown key '{}' with value '{}' (type: '{}').".format(
+                             key, data[key], type(data[key])))
             if key in expected_keys:
                 pytest.check(
                     isinstance(data[key], schema[key]),

--- a/usmqe/api/base.py
+++ b/usmqe/api/base.py
@@ -88,9 +88,10 @@ class ApiBase(object):
             "Data should contains keys: {}".format(expected_keys))
         for key in keys:
             pytest.check(key in expected_keys,
-                         "Unknown key '{}' with value '{}' (type: '{}').".format(
-                             key, data[key], type(data[key])))
+                         "Unknown key '{}' with value '{}' (type: '{}').\
+                         ".format(key, data[key], type(data[key])))
             if key in expected_keys:
                 pytest.check(
                     isinstance(data[key], schema[key]),
-                    "{} should be instance of {}".format(data[key], schema[key]))
+                    "{} should be instance of {}".format(data[key],
+                                                         schema[key]))

--- a/usmqe/api/base.py
+++ b/usmqe/api/base.py
@@ -60,7 +60,10 @@ class ApiBase(object):
         try:
             json.dumps(resp.json(encoding='unicode'))
         except ValueError as err:
-            pytest.check(False, "Bad response json format: '{}'".format(err))
+            pytest.check(
+                False,
+                "Bad response '{}' json format: '{}'".format(resp, err)
+                )
         pytest.check(
             resp.ok == asserts["ok"],
             "There should be ok == {}".format(str(asserts["ok"])))

--- a/usmqe/api/tendrlapi/cephapi.py
+++ b/usmqe/api/tendrlapi/cephapi.py
@@ -1,7 +1,6 @@
 """
 Tendrl REST API for ceph.
 """
-import json
 import pytest
 import requests
 from usmqe.api.tendrlapi.common import TendrlApi
@@ -67,10 +66,9 @@ class TendrlApiCeph(TendrlApi):
                 pool_data["Pool.quota_max_objects"] = quota_max_objects
             if quota_max_bytes:
                 pool_data["Pool.quota_max_bytes"] = quota_max_bytes
-
         response = requests.post(
             pytest.config.getini("usm_api_url") + pattern,
-            json=json.dumps(pool_data),
+            json=pool_data,
             auth=self._auth)
         asserts = {
             "reason": 'Accepted',
@@ -107,7 +105,7 @@ class TendrlApiCeph(TendrlApi):
             quota_max_objects: Maximum number of object in pool. (Int)
             quota_max_bytes: Maximum number of bytes in pool. (Int)
         """
-        pattern = "{}/CephCreatePool".format(cluster)
+        pattern = "{}/CephUpdatePool".format(cluster)
         pool_data = {"Pool.pool_id": pool_id}
 
         if name:
@@ -127,7 +125,7 @@ class TendrlApiCeph(TendrlApi):
 
         response = requests.put(
             pytest.config.getini("usm_api_url") + pattern,
-            json=json.dumps(pool_data),
+            json=pool_data,
             auth=self._auth)
         asserts = {
             "reason": 'Accepted',
@@ -171,7 +169,7 @@ class TendrlApiCeph(TendrlApi):
         pool_data = {"Pool.pool_id": pool_id}
         response = requests.delete(
             pytest.config.getini("usm_api_url") + pattern,
-            json=json.dumps(pool_data),
+            json=pool_data,
             auth=self._auth)
         asserts = {
             "reason": 'Accepted',
@@ -201,7 +199,7 @@ class TendrlApiCeph(TendrlApi):
                     }
         response = requests.post(
             pytest.config.getini("usm_api_url") + pattern,
-            json=json.dumps(pool_data),
+            json=pool_data,
             auth=self._auth)
         asserts = {
             "reason": 'Accepted',
@@ -231,7 +229,7 @@ class TendrlApiCeph(TendrlApi):
                     }
         response = requests.put(
             pytest.config.getini("usm_api_url") + pattern,
-            json=json.dumps(pool_data),
+            json=pool_data,
             auth=self._auth)
         asserts = {
             "reason": 'Accepted',
@@ -257,7 +255,7 @@ class TendrlApiCeph(TendrlApi):
         pool_data = {"Rbd.pool_id": pool_id, "Rbd.name": name}
         response = requests.delete(
             pytest.config.getini("usm_api_url") + pattern,
-            json=json.dumps(pool_data),
+            json=pool_data,
             auth=self._auth)
         asserts = {
             "reason": 'Accepted',
@@ -296,7 +294,7 @@ class TendrlApiCeph(TendrlApi):
                     }
         response = requests.post(
             pytest.config.getini("usm_api_url") + pattern,
-            json=json.dumps(pool_data),
+            json=pool_data,
             auth=self._auth)
         asserts = {
             "reason": 'Accepted',
@@ -321,7 +319,7 @@ class TendrlApiCeph(TendrlApi):
         pool_data = {"ECProfile.name": name}
         response = requests.delete(
             pytest.config.getini("usm_api_url") + pattern,
-            json=json.dumps(pool_data),
+            json=pool_data,
             auth=self._auth)
         asserts = {
             "reason": 'Accepted',

--- a/usmqe/api/tendrlapi/cephapi.py
+++ b/usmqe/api/tendrlapi/cephapi.py
@@ -1,8 +1,9 @@
 """
 Tendrl REST API for ceph.
 """
-
+import json
 import pytest
+import requests
 from usmqe.api.tendrlapi.common import TendrlApi
 
 LOGGER = pytest.get_logger("tendrlapi_ceph", module=True)
@@ -19,3 +20,313 @@ class TendrlApiCeph(TendrlApi):
             asserts_in (dict): assert values for this call and this method
         """
         return super().import_cluster(nodes, "ceph", asserts_in)
+
+    def create_pool(self,
+                    cluster,
+                    name,
+                    pg_num,
+                    min_size,
+                    size,
+                    pool_type=None,
+                    erasure_code_profile=None,
+                    quota_enabled=None,
+                    quota_max_objects=None,
+                    quota_max_bytes=None):
+        """ Create Ceph pool.
+
+        Name:        "create_pool",
+        Method:      "POST",
+        Pattern:     ":cluster_id:/CephCreatePool",
+
+        Args:
+            cluster: Cluster ID (String)
+            name: Pool name. (String)
+            pg_num: Number of placement groups. (Int)
+            min_size: Minimum number of replicas required for I/O in degraded state (Int)
+            size: Minimum number of replicas required for I/O. (Int)
+            pool_type: Type of the Ceph pool(ec or replicated) (String)
+            erasure_code_profile: For erasure pools only.It must be an existing profile. (String)
+            quota_enabled: Enable quota for the pool. (Bool)
+            quota_max_objects: Maximum number of object in pool. (Int)
+            quota_max_bytes: Maximum number of bytes in pool. (Int)
+        """
+        pattern = "{}/CephCreatePool".format(cluster)
+        pool_data = {
+            "Pool.poolname": name,
+            "Pool.pg_num": pg_num,
+            "Pool.min_size": min_size,
+            "Pool.size": size,
+            }
+        if pool_type:
+            pool_data["Pool.type"] = pool_type
+        if erasure_code_profile:
+            pool_data["Pool.erasure_code_profile"] = erasure_code_profile
+        if quota_enabled is not None and (quota_max_objects or quota_max_bytes):
+            pool_data["Pool.quota_enabled"] = quota_enabled
+            if quota_max_objects:
+                pool_data["Pool.quota_max_objects"] = quota_max_objects
+            if quota_max_bytes:
+                pool_data["Pool.quota_max_bytes"] = quota_max_bytes
+
+        response = requests.post(
+            pytest.config.getini("usm_api_url") + pattern,
+            json=json.dumps(pool_data),
+            auth=self._auth)
+        asserts = {
+            "reason": 'Accepted',
+            "status": 202,
+        }
+        self.print_req_info(response)
+        self.check_response(response, asserts)
+        return response.json()
+
+    def update_pool(self,
+                    cluster,
+                    pool_id,
+                    name=None,
+                    size=None,
+                    min_size=None,
+                    pg_num=None,
+                    quota_enabled=None,
+                    quota_max_objects=None,
+                    quota_max_bytes=None):
+        """ Update Ceph pool.
+
+        Name:        "update_pool",
+        Method:      "PUT",
+        Pattern:     ":cluster_id:/CephUpdatePool",
+
+        Args:
+            cluster: Cluster ID (String)
+            pool_id: Pool ID (String)
+            name: Pool name. (String)
+            size: Minimum number of replicas required for I/O. (Int)
+            min_size: Minimum number of replicas required for I/O in degraded state (Int)
+            pg_num: Number of placement groups. (Int)
+            quota_enabled: Enable quota for the pool. (Bool)
+            quota_max_objects: Maximum number of object in pool. (Int)
+            quota_max_bytes: Maximum number of bytes in pool. (Int)
+        """
+        pattern = "{}/CephCreatePool".format(cluster)
+        pool_data = {"Pool.pool_id": pool_id}
+
+        if name:
+            pool_data["Pool.poolname"] = name
+        if size:
+            pool_data["Pool.size"] = size
+        if min_size:
+            pool_data["Pool.min_size"] = min_size
+        if pg_num:
+            pool_data["Pool.pg_num"] = pg_num
+        if quota_enabled is not None and (quota_max_bytes or quota_max_objects):
+            pool_data["Pool.quota_enabled"] = quota_enabled
+            if quota_max_objects:
+                pool_data["Pool.quota_max_objects"] = quota_max_objects
+            if quota_max_bytes:
+                pool_data["Pool.quota_max_bytes"] = quota_max_bytes
+
+        response = requests.put(
+            pytest.config.getini("usm_api_url") + pattern,
+            json=json.dumps(pool_data),
+            auth=self._auth)
+        asserts = {
+            "reason": 'Accepted',
+            "status": 202,
+        }
+        self.print_req_info(response)
+        self.check_response(response, asserts)
+        return response.json()
+
+
+    def get_pool_list(self, cluster):
+        """ Get pool list for specific Ceph cluster.
+
+        Name:        "get_pool_list",
+        Method:      "GET",
+        Pattern:     ":cluster_id:/GetPoolList",
+
+        Args:
+            cluster: Cluster ID. (String)
+        """
+        pattern = "{}/GetPoolList".format(cluster)
+        response = requests.get(
+            pytest.config.getini("usm_api_url") + pattern,
+            auth=self._auth)
+        self.print_req_info(response)
+        self.check_response(response)
+        return response.json()
+
+    def delete_pool(self, cluster, pool_id):
+        """ Delete Ceph pool.
+
+        Name:        "delete_pool",
+        Method:      "DELETE",
+        Pattern:     ":cluster_id:/CephDeletePool",
+
+        Args:
+            cluster: Cluster ID (String)
+            pool_id: Pool ID (String)
+        """
+        pattern = "{}/CephDeletePool".format(cluster)
+        pool_data = {"Pool.pool_id": pool_id}
+        response = requests.delete(
+            pytest.config.getini("usm_api_url") + pattern,
+            json=json.dumps(pool_data),
+            auth=self._auth)
+        asserts = {
+            "reason": 'Accepted',
+            "status": 202,
+        }
+        self.print_req_info(response)
+        self.check_response(response, asserts)
+        return response.json()
+
+    def create_rbd(self, cluster, pool_id, name, size):
+        """ Create RBD in Ceph pool.
+
+        Name:        "create_rbd",
+        Method:      "POST",
+        Pattern:     ":cluster_id:/CephCreateRbd",
+
+        Args:
+            cluster: Cluster ID (String)
+            pool_id: Pool ID (String)
+            name: RBD name (String)
+            size: RBD size (Int)
+        """
+        pattern = "{}/CephCreateRbd".format(cluster)
+        pool_data = {"Rbd.pool_id": pool_id,
+                     "Rbd.name": name,
+                     "Rbd.size": size
+                    }
+        response = requests.post(
+            pytest.config.getini("usm_api_url") + pattern,
+            json=json.dumps(pool_data),
+            auth=self._auth)
+        asserts = {
+            "reason": 'Accepted',
+            "status": 202,
+        }
+        self.print_req_info(response)
+        self.check_response(response, asserts)
+        return response.json()
+
+    def update_rbd(self, cluster, pool_id, name, size):
+        """ Update RBD in Ceph pool.
+
+        Name:        "update_rbd",
+        Method:      "PUT",
+        Pattern:     ":cluster_id:/CephResizeRbd",
+
+        Args:
+            cluster: Cluster ID (String)
+            pool_id: Pool ID (String)
+            name: RBD name (String)
+            size: RBD size (Int)
+        """
+        pattern = "{}/CephResizeRbd".format(cluster)
+        pool_data = {"Rbd.pool_id": pool_id,
+                     "Rbd.name": name,
+                     "Rbd.size": size
+                    }
+        response = requests.put(
+            pytest.config.getini("usm_api_url") + pattern,
+            json=json.dumps(pool_data),
+            auth=self._auth)
+        asserts = {
+            "reason": 'Accepted',
+            "status": 202,
+        }
+        self.print_req_info(response)
+        self.check_response(response, asserts)
+        return response.json()
+
+    def delete_rbd(self, cluster, pool_id, name):
+        """ Delete RBD in Ceph pool.
+
+        Name:        "delete_rbd",
+        Method:      "DELETE",
+        Pattern:     ":cluster_id:/CephRbd",
+
+        Args:
+            cluster: Cluster ID (String)
+            pool_id: Pool ID (String)
+            name: RBD name (String)
+        """
+        pattern = "{}/CephDeleteRbd".format(cluster)
+        pool_data = {"Rbd.pool_id": pool_id, "Rbd.name": name}
+        response = requests.delete(
+            pytest.config.getini("usm_api_url") + pattern,
+            json=json.dumps(pool_data),
+            auth=self._auth)
+        asserts = {
+            "reason": 'Accepted',
+            "status": 202,
+        }
+        self.print_req_info(response)
+        self.check_response(response, asserts)
+        return response.json()
+
+    def create_ecprofile(self, cluster, name, k_ec, m_ec,
+                         plugin=None,
+                         directory=None,
+                         ruleset_fail_dom=None):
+        """ Create EC profile.
+
+        Name:        "create_ecprofile",
+        Method:      "POST",
+        Pattern:     ":cluster_id:/CephCreateECProfile",
+
+        Args:
+            cluster: Cluster ID (String)
+            name: EC profile name (String)
+            k_ec: k value for ec profile (Int)
+            m_ec: m value for ec profile (Int)
+            plugin: EC profile plugin (String)
+            directory: directory for EC profile (String)
+            ruleset_fail_dom: rule set failure domain for EC profile (String)
+        """
+        pattern = "{}/CephCreateECProfile".format(cluster)
+        pool_data = {"ECProfile.name": name,
+                     "ECProfile.k": k_ec,
+                     "ECProfile.m": m_ec,
+                     "ECProfile.plugin": plugin,
+                     "ECProfile.directory": directory,
+                     "ECProfile.ruleset_failure_domain": ruleset_fail_dom,
+                    }
+        response = requests.post(
+            pytest.config.getini("usm_api_url") + pattern,
+            json=json.dumps(pool_data),
+            auth=self._auth)
+        asserts = {
+            "reason": 'Accepted',
+            "status": 202,
+        }
+        self.print_req_info(response)
+        self.check_response(response, asserts)
+        return response.json()
+
+    def delete_ecprofile(self, cluster, name):
+        """ Delete EC profile.
+
+        Name:        "delete_ecprofile",
+        Method:      "DELETE",
+        Pattern:     ":cluster_id:/CephCreateECProfile",
+
+        Args:
+            cluster: Cluster ID (String)
+            name: EC profile name (String)
+        """
+        pattern = "{}/CephDeleteECProfile".format(cluster)
+        pool_data = {"ECProfile.name": name}
+        response = requests.delete(
+            pytest.config.getini("usm_api_url") + pattern,
+            json=json.dumps(pool_data),
+            auth=self._auth)
+        asserts = {
+            "reason": 'Accepted',
+            "status": 202,
+        }
+        self.print_req_info(response)
+        self.check_response(response, asserts)
+        return response.json()

--- a/usmqe/api/tendrlapi/cephapi.py
+++ b/usmqe/api/tendrlapi/cephapi.py
@@ -39,18 +39,18 @@ class TendrlApiCeph(TendrlApi):
         Pattern:     ":cluster_id:/CephCreatePool",
 
         Args:
-            cluster: Cluster ID (String)
-            name: Pool name. (String)
-            pg_num: Number of placement groups. (Int)
-            min_size: Minimum number of replicas required for I/O
-                      in degraded state (Int)
-            size: Number of replicas required for I/O. (Int)
-            pool_type: Type of the Ceph pool (ec or replicated) (String)
-            erasure_code_profile: For erasure pools only. It must be
-                                  an existing profile. (String)
-            quota_enabled: Enable quota for the pool. (Bool)
-            quota_max_objects: Maximum number of object in pool. (Int)
-            quota_max_bytes: Maximum number of bytes in pool. (Int)
+            cluster (str): Cluster ID
+            name (str): Pool name.
+            pg_num (int): Number of placement groups.
+            min_size (int): Minimum number of replicas required for I/O
+                      in degraded state
+            size (int): Number of replicas required for I/O.
+            pool_type (str): Type of the Ceph pool (ec or replicated)
+            erasure_code_profile (str): For erasure pools only. It must be
+                                  an existing profile.
+            quota_enabled (bool): Enable quota for the pool.
+            quota_max_objects (int): Maximum number of object in pool.
+            quota_max_bytes (int): Maximum number of bytes in pool.
             asserts_in (dict): assert values for this call and this method
         """
         pattern = "{}/CephCreatePool".format(cluster)
@@ -101,16 +101,16 @@ class TendrlApiCeph(TendrlApi):
         Pattern:     ":cluster_id:/CephUpdatePool",
 
         Args:
-            cluster: Cluster ID (String)
-            pool_id: Pool ID (String)
-            name: Pool name. (String)
-            size: Number of replicas required for I/O. (Int)
-            min_size: Minimum number of replicas required for I/O
-                      in degraded state (Int)
-            pg_num: Number of placement groups. (Int)
-            quota_enabled: Enable quota for the pool. (Bool)
-            quota_max_objects: Maximum number of object in pool. (Int)
-            quota_max_bytes: Maximum number of bytes in pool. (Int)
+            cluster (str): Cluster ID
+            pool_id (str): Pool ID
+            name (str): Pool name.
+            size (int): Number of replicas required for I/O.
+            min_size (int): Minimum number of replicas required for I/O
+                      in degraded state
+            pg_num (int): Number of placement groups.
+            quota_enabled (bool): Enable quota for the pool.
+            quota_max_objects (int): Maximum number of object in pool.
+            quota_max_bytes (int): Maximum number of bytes in pool.
             asserts_in (dict): assert values for this call and this method
         """
         pattern = "{}/CephUpdatePool".format(cluster)
@@ -153,7 +153,7 @@ class TendrlApiCeph(TendrlApi):
         Pattern:     ":cluster_id:/GetPoolList",
 
         Args:
-            cluster: Cluster ID. (String)
+            cluster (str): Cluster ID.
             asserts_in (dict): assert values for this call and this method
         """
         pattern = "{}/GetPoolList".format(cluster)
@@ -161,7 +161,7 @@ class TendrlApiCeph(TendrlApi):
             pytest.config.getini("usm_api_url") + pattern,
             auth=self._auth)
         self.print_req_info(response)
-        self.check_response(response)
+        self.check_response(response, asserts_in)
         return response.json()
 
     def delete_pool(self, cluster, pool_id, asserts_in=None):
@@ -172,8 +172,8 @@ class TendrlApiCeph(TendrlApi):
         Pattern:     ":cluster_id:/CephDeletePool",
 
         Args:
-            cluster: Cluster ID (String)
-            pool_id: Pool ID (String)
+            cluster (str): Cluster ID
+            pool_id (str): Pool ID
             asserts_in (dict): assert values for this call and this method
         """
         pattern = "{}/CephDeletePool".format(cluster)
@@ -199,10 +199,10 @@ class TendrlApiCeph(TendrlApi):
         Pattern:     ":cluster_id:/CephCreateRbd",
 
         Args:
-            cluster: Cluster ID (String)
-            pool_id: Pool ID (String)
-            name: RBD name (String)
-            size: RBD size (Int)
+            cluster (str): Cluster ID
+            pool_id (str): Pool ID
+            name (str): RBD name
+            size (int): RBD size
             asserts_in (dict): assert values for this call and this method
         """
         pattern = "{}/CephCreateRbd".format(cluster)
@@ -231,10 +231,10 @@ class TendrlApiCeph(TendrlApi):
         Pattern:     ":cluster_id:/CephResizeRbd",
 
         Args:
-            cluster: Cluster ID (String)
-            pool_id: Pool ID (String)
-            name: RBD name (String)
-            size: RBD size (Int)
+            cluster (str): Cluster ID
+            pool_id (str): Pool ID
+            name (str): RBD name
+            size (int): RBD size
             asserts_in (dict): assert values for this call and this method
         """
         pattern = "{}/CephResizeRbd".format(cluster)
@@ -260,12 +260,12 @@ class TendrlApiCeph(TendrlApi):
 
         Name:        "delete_rbd",
         Method:      "DELETE",
-        Pattern:     ":cluster_id:/CephRbd",
+        Pattern:     ":cluster_id:/CephiDeleteRbd",
 
         Args:
-            cluster: Cluster ID (String)
-            pool_id: Pool ID (String)
-            name: RBD name (String)
+            cluster (str): Cluster ID
+            pool_id (str): Pool ID
+            name (str): RBD name
             asserts_in (dict): assert values for this call and this method
         """
         pattern = "{}/CephDeleteRbd".format(cluster)
@@ -295,13 +295,13 @@ class TendrlApiCeph(TendrlApi):
         Pattern:     ":cluster_id:/CephCreateECProfile",
 
         Args:
-            cluster: Cluster ID (String)
-            name: EC profile name (String)
-            k_ec: k value for ec profile (Int)
-            m_ec: m value for ec profile (Int)
-            plugin: EC profile plugin (String)
-            directory: directory for EC profile (String)
-            ruleset_fail_dom: rule set failure domain for EC profile (String)
+            cluster (str): Cluster ID
+            name (str): EC profile name
+            k_ec (int): k value for ec profile
+            m_ec (int): m value for ec profile
+            plugin (str): EC profile plugin
+            directory (str): directory for EC profile
+            ruleset_fail_dom (str): rule set failure domain for EC profile
             asserts_in (dict): assert values for this call and this method
         """
         pattern = "{}/CephCreateECProfile".format(cluster)
@@ -330,11 +330,11 @@ class TendrlApiCeph(TendrlApi):
 
         Name:        "delete_ecprofile",
         Method:      "DELETE",
-        Pattern:     ":cluster_id:/CephCreateECProfile",
+        Pattern:     ":cluster_id:/CephDeleteECProfile",
 
         Args:
-            cluster: Cluster ID (String)
-            name: EC profile name (String)
+            cluster (str): Cluster ID
+            name (str): EC profile name
             asserts_in (dict): assert values for this call and this method
         """
         pattern = "{}/CephDeleteECProfile".format(cluster)

--- a/usmqe/api/tendrlapi/cephapi.py
+++ b/usmqe/api/tendrlapi/cephapi.py
@@ -41,10 +41,12 @@ class TendrlApiCeph(TendrlApi):
             cluster: Cluster ID (String)
             name: Pool name. (String)
             pg_num: Number of placement groups. (Int)
-            min_size: Minimum number of replicas required for I/O in degraded state (Int)
+            min_size: Minimum number of replicas required for I/O
+                      in degraded state (Int)
             size: Minimum number of replicas required for I/O. (Int)
             pool_type: Type of the Ceph pool(ec or replicated) (String)
-            erasure_code_profile: For erasure pools only.It must be an existing profile. (String)
+            erasure_code_profile: For erasure pools only.It must be
+                                  an existing profile. (String)
             quota_enabled: Enable quota for the pool. (Bool)
             quota_max_objects: Maximum number of object in pool. (Int)
             quota_max_bytes: Maximum number of bytes in pool. (Int)
@@ -99,7 +101,8 @@ class TendrlApiCeph(TendrlApi):
             pool_id: Pool ID (String)
             name: Pool name. (String)
             size: Minimum number of replicas required for I/O. (Int)
-            min_size: Minimum number of replicas required for I/O in degraded state (Int)
+            min_size: Minimum number of replicas required for I/O
+                      in degraded state (Int)
             pg_num: Number of placement groups. (Int)
             quota_enabled: Enable quota for the pool. (Bool)
             quota_max_objects: Maximum number of object in pool. (Int)
@@ -134,7 +137,6 @@ class TendrlApiCeph(TendrlApi):
         self.print_req_info(response)
         self.check_response(response, asserts)
         return response.json()
-
 
     def get_pool_list(self, cluster):
         """ Get pool list for specific Ceph cluster.
@@ -196,7 +198,7 @@ class TendrlApiCeph(TendrlApi):
         pool_data = {"Rbd.pool_id": pool_id,
                      "Rbd.name": name,
                      "Rbd.size": size
-                    }
+                     }
         response = requests.post(
             pytest.config.getini("usm_api_url") + pattern,
             json=pool_data,
@@ -226,7 +228,7 @@ class TendrlApiCeph(TendrlApi):
         pool_data = {"Rbd.pool_id": pool_id,
                      "Rbd.name": name,
                      "Rbd.size": size
-                    }
+                     }
         response = requests.put(
             pytest.config.getini("usm_api_url") + pattern,
             json=pool_data,
@@ -291,7 +293,7 @@ class TendrlApiCeph(TendrlApi):
                      "ECProfile.plugin": plugin,
                      "ECProfile.directory": directory,
                      "ECProfile.ruleset_failure_domain": ruleset_fail_dom,
-                    }
+                     }
         response = requests.post(
             pytest.config.getini("usm_api_url") + pattern,
             json=pool_data,

--- a/usmqe/api/tendrlapi/cephapi.py
+++ b/usmqe/api/tendrlapi/cephapi.py
@@ -260,7 +260,7 @@ class TendrlApiCeph(TendrlApi):
 
         Name:        "delete_rbd",
         Method:      "DELETE",
-        Pattern:     ":cluster_id:/CephiDeleteRbd",
+        Pattern:     ":cluster_id:/CephDeleteRbd",
 
         Args:
             cluster (str): Cluster ID

--- a/usmqe/ceph/ceph_cluster.py
+++ b/usmqe/ceph/ceph_cluster.py
@@ -194,9 +194,7 @@ class CephCluster(CephCommon):
 
             {'fsid': 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'}
         """
-        # WORKAROUND for https://github.com/tomerfiliba/plumbum/issues/275
-        # return self.run_on_mon('fsid')
-        return self.run_on_mon('fsid && echo || (echo; false)')
+        return self.run_on_mon('fsid')
 
     def health(self):
         """
@@ -294,9 +292,7 @@ class CephCluster(CephCommon):
               'timestamp': '2016-04-12 15:49:13.060559',
               'version': '0.94.5-9.el7cp',}
         """
-        # WORKAROUND for https://github.com/tomerfiliba/plumbum/issues/275
-        # return self.run_on_mon('report')
-        return self.run_on_mon('report && echo || (echo; false)')
+        return self.run_on_mon('report')
 
     def status(self):
         """
@@ -491,10 +487,7 @@ class CephClusterOsd(CephCommon):
               'ip': '172.16.180.1:6804/28484',
               'osd': 1,}
         """
-        # WORKAROUND for https://github.com/tomerfiliba/plumbum/issues/275
-        # return self.run_on_mon('osd find {}'.format(osd_id))
-        return self.run_on_mon('osd find {} && echo || (echo; false)'.
-                               format(osd_id))
+        return self.run_on_mon('osd find {}'.format(osd_id))
 
     # pylint - allow short method name
     def ls(self, epoch=None):  # pylint: disable=C0103
@@ -563,10 +556,7 @@ class CephClusterOsd(CephCommon):
               'osd_journal': '/var/lib/ceph/osd/TestClusterA-0/journal',
               'osd_objectstore': 'filestore',}
         """
-        # WORKAROUND for https://github.com/tomerfiliba/plumbum/issues/275
-        # return self.run_on_mon('osd metadata {}'.format(osd_id))
-        return self.run_on_mon(
-            'osd metadata {} && echo || (echo; false)'.format(osd_id))
+        return self.run_on_mon('osd metadata {}'.format(osd_id))
 
     def perf(self):
         """
@@ -606,9 +596,7 @@ class CephClusterOsd(CephCommon):
               'num_remapped_pgs': 0,
               'num_up_osds': 8}
         """
-        # WORKAROUND for https://github.com/tomerfiliba/plumbum/issues/275
-        # return self.run_on_mon('osd stat')
-        return self.run_on_mon('osd stat && echo || (echo; false)')
+        return self.run_on_mon('osd stat')
 
     def tree(self):
         """
@@ -656,6 +644,10 @@ class CephClusterOsd(CephCommon):
     def pool_ls(self, detail=False):
         """
         Run ceph command: ``osd pool ls {detail}``
+
+        Args:
+            detail: If it equals to True function call output
+                    contains pool details
 
         Returns:
             dictionary: parsed json from
@@ -776,7 +768,4 @@ class CephClusterStorage(CephCommon):
               'total_used': '280276',}
         """
         pool_str = "--pool {}".format(pool) if pool else ""
-        # WORKAROUND for https://github.com/tomerfiliba/plumbum/issues/275
-        # return self.run_on_mon('df')
-        return self.run_on_mon('df {} && echo || (echo; false)'.
-                               format(pool_str))
+        return self.run_on_mon('df {}'.format(pool_str))

--- a/usmqe/ceph/ceph_cluster.py
+++ b/usmqe/ceph/ceph_cluster.py
@@ -722,12 +722,12 @@ class CephClusterOsd(CephCommon):
              "options": {}
            }
          ]
- 
         """
         if detail:
             return self.run_on_mon('osd pool ls detail')
         else:
             return self.run_on_mon('osd pool ls')
+
 
 class CephClusterStorage(CephCommon):
     """

--- a/usmqe/ceph/ceph_cluster.py
+++ b/usmqe/ceph/ceph_cluster.py
@@ -653,6 +653,81 @@ class CephClusterOsd(CephCommon):
         """
         return self.run_on_mon('osd tree')
 
+    def pool_ls(self, detail=False):
+        """
+        Run ceph command: ``osd pool ls {detail}``
+
+        Returns:
+            dictionary: parsed json from
+                        ``ceph --format json --cluster CLUSTERNAME osd pool ls {detail}``
+                        command
+
+        Example output (only root elements)::
+        [
+            "rbd"
+        ]
+
+        and with detail=True
+
+        [
+          {
+             "pool_name": "rbd",
+             "flags": 1,
+             "flags_names": "hashpspool",
+             "type": 1,
+             "size": 3,
+             "min_size": 2,
+             "crush_ruleset": 0,
+             "object_hash": 2,
+             "pg_num": 64,
+             "pg_placement_num": 64,
+             "crash_replay_interval": 0,
+             "last_change": "1",
+             "last_force_op_resend": "0",
+             "auid": 0,
+             "snap_mode": "selfmanaged",
+             "snap_seq": 0,
+             "snap_epoch": 0,
+             "pool_snaps": [],
+             "removed_snaps": "[]",
+             "quota_max_bytes": 0,
+             "quota_max_objects": 0,
+             "tiers": [],
+             "tier_of": -1,
+             "read_tier": -1,
+             "write_tier": -1,
+             "cache_mode": "none",
+             "target_max_bytes": 0,
+             "target_max_objects": 0,
+             "cache_target_dirty_ratio_micro": 0,
+             "cache_target_dirty_high_ratio_micro": 0,
+             "cache_target_full_ratio_micro": 0,
+             "cache_min_flush_age": 0,
+             "cache_min_evict_age": 0,
+             "erasure_code_profile": "",
+             "hit_set_params": {
+               "type": "none"
+             },
+             "hit_set_period": 0,
+             "hit_set_count": 0,
+             "use_gmt_hitset": true,
+             "min_read_recency_for_promote": 0,
+             "min_write_recency_for_promote": 0,
+             "hit_set_grade_decay_rate": 0,
+             "hit_set_search_last_n": 0,
+             "grade_table": [],
+             "stripe_width": 0,
+             "expected_num_objects": 0,
+             "fast_read": false,
+             "options": {}
+           }
+         ]
+ 
+        """
+        if detail:
+            return self.run_on_mon('osd pool ls detail')
+        else:
+            return self.run_on_mon('osd pool ls')
 
 class CephClusterStorage(CephCommon):
     """

--- a/usmqe/ceph/commands.py
+++ b/usmqe/ceph/commands.py
@@ -1,7 +1,10 @@
 """
 Library for direct access to ceph commands.
+NOTE: If user would like to use this module with different key than id_rsa,
+it should be imported inside testcase and not in usual python import section
 
 .. moduleauthor:: dahorak@redhat.com
+.. moduleauthor:: mkudlej@redhat.com
 """
 
 import pytest
@@ -10,6 +13,11 @@ import usmqe.usmssh
 
 
 LOGGER = pytest.get_logger('usmceph.commands', module=True)
+usmqe.usmssh.KEYFILE="~/.ssh/id_rsa"
+try:
+    usmqe.usmssh.KEYFILE=pytest.config.getini("usm_ssh_keyfile")
+except ValueError:
+    pass
 SSH = usmqe.usmssh.get_ssh()
 
 
@@ -33,8 +41,12 @@ class CephCommand(object):
         format_str = "--format {}".format(self._format) if self._format else ""
         timeout_str = "--connect-timeout {}".format(self._timeout) \
                       if self._timeout else ""
-        return "{} {} {} {}".format(
+        cmd = "{} {} {} {}".format(
             self._base_command, timeout_str, format_str, command)
+        # TODO EOL workaround because of https://bugzilla.redhat.com/show_bug.cgi?id=1448057
+        if self._format == 'json':
+            cmd = "{} {}".format(cmd, "; echo ''")
+        return cmd
 
     def run(self, host, command):
         """
@@ -79,6 +91,9 @@ class CephClusterCommand(CephCommand):
         cmd = "{} {} {} {} {} {}".format(
             self._base_command, timeout_str, format_str, cluster_str,
             conf_str, command)
+        # TODO EOL workaround because of https://bugzilla.redhat.com/show_bug.cgi?id=1448057
+        if self._format == 'json':
+            cmd = "{} {}".format(cmd, "; echo ''")
         return cmd
 
 
@@ -107,6 +122,9 @@ class RadosCommand(CephCommand):
 
         cmd = "{} {} {} {} {}".format(
             self._base_command, format_str, cluster_str, conf_str, command)
+        # TODO EOL workaround because of https://bugzilla.redhat.com/show_bug.cgi?id=1448057
+        if self._format == 'json':
+            cmd = "{} {}".format(cmd, "; echo ''")
         return cmd
 
 
@@ -138,6 +156,9 @@ class RBDCommand(CephCommand):
         cmd = "{} {} {} {} {} {}".format(
             self._base_command, format_str, cluster_str,
             conf_str, pool_str, command)
+        # TODO EOL workaround because of https://bugzilla.redhat.com/show_bug.cgi?id=1448057
+        if self._format == 'json':
+            cmd = "{} {}".format(cmd, "; echo ''")
         return cmd
 
 

--- a/usmqe/ceph/commands.py
+++ b/usmqe/ceph/commands.py
@@ -13,11 +13,6 @@ import usmqe.usmssh
 
 
 LOGGER = pytest.get_logger('usmceph.commands', module=True)
-usmqe.usmssh.KEYFILE = "~/.ssh/id_rsa"
-try:
-    usmqe.usmssh.KEYFILE = pytest.config.getini("usm_ssh_keyfile")
-except ValueError:
-    pass
 SSH = usmqe.usmssh.get_ssh()
 
 
@@ -44,8 +39,8 @@ class CephCommand(object):
         cmd = "{} {} {} {}".format(
             self._base_command, timeout_str, format_str, command)
         # TODO EOL workaround because of https://bugzilla.redhat.com/show_bug.cgi?id=1448057
-        if self._format == 'json':
-            cmd = "{} {}".format(cmd, "; echo ''")
+        # and for https://github.com/tomerfiliba/plumbum/issues/275
+        cmd = "{} {}".format(cmd, "&& echo || (echo; false)")
         return cmd
 
     def run(self, host, command):
@@ -92,8 +87,8 @@ class CephClusterCommand(CephCommand):
             self._base_command, timeout_str, format_str, cluster_str,
             conf_str, command)
         # TODO EOL workaround because of https://bugzilla.redhat.com/show_bug.cgi?id=1448057
-        if self._format == 'json':
-            cmd = "{} {}".format(cmd, "; echo ''")
+        # and for https://github.com/tomerfiliba/plumbum/issues/275
+        cmd = "{} {}".format(cmd, "&& echo || (echo; false)")
         return cmd
 
 
@@ -123,8 +118,8 @@ class RadosCommand(CephCommand):
         cmd = "{} {} {} {} {}".format(
             self._base_command, format_str, cluster_str, conf_str, command)
         # TODO EOL workaround because of https://bugzilla.redhat.com/show_bug.cgi?id=1448057
-        if self._format == 'json':
-            cmd = "{} {}".format(cmd, "; echo ''")
+        # and for https://github.com/tomerfiliba/plumbum/issues/275
+        cmd = "{} {}".format(cmd, "&& echo || (echo; false)")
         return cmd
 
 
@@ -157,8 +152,8 @@ class RBDCommand(CephCommand):
             self._base_command, format_str, cluster_str,
             conf_str, pool_str, command)
         # TODO EOL workaround because of https://bugzilla.redhat.com/show_bug.cgi?id=1448057
-        if self._format == 'json':
-            cmd = "{} {}".format(cmd, "; echo ''")
+        # and for https://github.com/tomerfiliba/plumbum/issues/275
+        cmd = "{} {}".format(cmd, "&& echo || (echo; false)")
         return cmd
 
 

--- a/usmqe/ceph/commands.py
+++ b/usmqe/ceph/commands.py
@@ -13,9 +13,9 @@ import usmqe.usmssh
 
 
 LOGGER = pytest.get_logger('usmceph.commands', module=True)
-usmqe.usmssh.KEYFILE="~/.ssh/id_rsa"
+usmqe.usmssh.KEYFILE = "~/.ssh/id_rsa"
 try:
-    usmqe.usmssh.KEYFILE=pytest.config.getini("usm_ssh_keyfile")
+    usmqe.usmssh.KEYFILE = pytest.config.getini("usm_ssh_keyfile")
 except ValueError:
     pass
 SSH = usmqe.usmssh.get_ssh()

--- a/usmqe/ceph/commands.py
+++ b/usmqe/ceph/commands.py
@@ -1,7 +1,5 @@
 """
 Library for direct access to ceph commands.
-NOTE: If user would like to use this module with different key than id_rsa,
-it should be imported inside testcase and not in usual python import section
 
 .. moduleauthor:: dahorak@redhat.com
 .. moduleauthor:: mkudlej@redhat.com

--- a/usmqe/usmssh.py
+++ b/usmqe/usmssh.py
@@ -5,10 +5,7 @@ Module for establishing remote ssh connection.
 
 Usage::
 
-    # configure SSH keyfile (once in e.g. run.py)
-    # default set to ~/.ssh/id_rsa
     import usmssh
-    usmssh.KEYFILE = "/path/to/id_rsa"
 
     # ...use SSH connection in any module...
     # and close all open ssh connections at the end
@@ -21,14 +18,11 @@ Usage::
 """
 
 
-import os
-
 import plumbum
 import pytest
 
 
 LOGGER = pytest.get_logger("ssh", module=True)
-KEYFILE = "~/.ssh/id_rsa"
 __SSH = None
 
 
@@ -73,7 +67,6 @@ class RemoteConnection(object):
     def __init__(self, node, user='root'):
         """
         Initializes and establishes connection for one user to one host.
-        It excepts properly configured KEYFILE variable.
 
         Parameters:
           * node - hostname
@@ -81,17 +74,15 @@ class RemoteConnection(object):
         """
         self.node = node
         self.user = user
-        self.keyfile = KEYFILE
-        self.establish_connection(
-            self.node, user=self.user, keyfile=self.keyfile)
+        self.establish_connection(self.node, user=self.user)
 
-    def establish_connection(self, node, user='root', keyfile=None):
+    def establish_connection(self, node, user='root'):
         """
         Establishes connection from localhost to node via plumbum.SshMachine.
         """
         try:
             self.ssh = plumbum.SshMachine(
-                node, user, keyfile=os.path.expanduser(keyfile),
+                node, user,
                 ssh_opts=('-o StrictHostKeyChecking=no',),
                 scp_opts=('-o StrictHostKeyChecking=no',))
             self.session = self.ssh.session()

--- a/usmqe_tests/api/ceph/conftest.py
+++ b/usmqe_tests/api/ceph/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from usmqe.api.tendrlapi import cephapi
 
+
 @pytest.fixture
 def valid_cluster_id(valid_session_credentials):
     """
@@ -11,7 +12,7 @@ def valid_cluster_id(valid_session_credentials):
     cluster_list = [cl for cl in api.get_cluster_list()
                     if cl["sds_name"] == "ceph" and
                     cl["cluster_name"] == pytest.config.getini("usm_ceph_cl_name")
-                   ]
+                    ]
     return cluster_list[0]["cluster_id"]
 
 
@@ -33,11 +34,12 @@ def valid_pool_id(valid_session_credentials):
     cluster_list = [cl for cl in api.get_cluster_list()
                     if cl["sds_name"] == "ceph" and
                     cl["cluster_name"] == pytest.config.getini("usm_ceph_cl_name")
-                   ]
+                    ]
     pools = cluster_list[0]["pools"]
     return [pool["pool_id"] for pool in pools.values()
             if pool["pool_name"] == pytest.config.getini("usm_pool_name")
-           ][0]
+            ][0]
+
 
 @pytest.fixture(params=[None, "0000000000000000"])
 def invalid_pool_id(request):
@@ -46,12 +48,14 @@ def invalid_pool_id(request):
     """
     return request.param
 
+
 @pytest.fixture(params=[0])
 def invalid_minsize(request):
     """
     Generate invalid min pool size(replicas).
     """
     return request.param
+
 
 @pytest.fixture(params=[0])
 def invalid_pg_num(request):
@@ -60,12 +64,14 @@ def invalid_pg_num(request):
     """
     return request.param
 
+
 @pytest.fixture(params=[" ", "*", "!", "_", "--"])
 def invalid_pool_name(request):
     """
     Generate invalid pool name.
     """
     return request.param
+
 
 @pytest.fixture(params=[0])
 def invalid_size(request):
@@ -74,12 +80,14 @@ def invalid_size(request):
     """
     return request.param
 
+
 @pytest.fixture(params=[2])
 def valid_minsize(request):
     """
     Generate valid min pool size(replicas).
     """
     return request.param
+
 
 @pytest.fixture(params=[128])
 def valid_pg_num(request):
@@ -88,12 +96,14 @@ def valid_pg_num(request):
     """
     return request.param
 
+
 @pytest.fixture
 def valid_pool_name():
     """
     Generate valid pool name.
     """
     return pytest.config.getini("usm_pool_name")
+
 
 @pytest.fixture(params=[3])
 def valid_size(request):

--- a/usmqe_tests/api/ceph/conftest.py
+++ b/usmqe_tests/api/ceph/conftest.py
@@ -29,7 +29,7 @@ def valid_pool_id(valid_session_credentials):
     """
     Generate valid id of a created volume.
     """
-#TODO change
+# TODO change
     api = cephapi.TendrlApiCeph(auth=valid_session_credentials)
     cluster_list = [cl for cl in api.get_cluster_list()
                     if cl["sds_name"] == "ceph" and

--- a/usmqe_tests/api/ceph/conftest.py
+++ b/usmqe_tests/api/ceph/conftest.py
@@ -1,0 +1,103 @@
+import pytest
+from usmqe.api.tendrlapi import cephapi
+
+@pytest.fixture
+def valid_cluster_id(valid_session_credentials):
+    """
+    Generate valid id of imported cluster.
+    """
+    # TODO change
+    api = cephapi.TendrlApiCeph(auth=valid_session_credentials)
+    cluster_list = [cl for cl in api.get_cluster_list()
+                    if cl["sds_name"] == "ceph" and
+                    cl["cluster_name"] == pytest.config.getini("usm_ceph_cl_name")
+                   ]
+    return cluster_list[0]["cluster_id"]
+
+
+@pytest.fixture(params=[None, "0000000000000000"])
+def invalid_cluster_id(request):
+    """
+    Generate invalid cluster id.
+    """
+    return request.param
+
+
+@pytest.fixture
+def valid_pool_id(valid_session_credentials):
+    """
+    Generate valid id of a created volume.
+    """
+#TODO change
+    api = cephapi.TendrlApiCeph(auth=valid_session_credentials)
+    cluster_list = [cl for cl in api.get_cluster_list()
+                    if cl["sds_name"] == "ceph" and
+                    cl["cluster_name"] == pytest.config.getini("usm_ceph_cl_name")
+                   ]
+    pools = cluster_list[0]["pools"]
+    return [pool["pool_id"] for pool in pools.values()
+            if pool["pool_name"] == pytest.config.getini("usm_pool_name")
+           ][0]
+
+@pytest.fixture(params=[None, "0000000000000000"])
+def invalid_pool_id(request):
+    """
+    Generate invalid volume id.
+    """
+    return request.param
+
+@pytest.fixture(params=[0])
+def invalid_minsize(request):
+    """
+    Generate invalid min pool size(replicas).
+    """
+    return request.param
+
+@pytest.fixture(params=[0])
+def invalid_pg_num(request):
+    """
+    Generate invalid pool pg number.
+    """
+    return request.param
+
+@pytest.fixture(params=[" ", "*", "!", "_", "--"])
+def invalid_pool_name(request):
+    """
+    Generate invalid pool name.
+    """
+    return request.param
+
+@pytest.fixture(params=[0])
+def invalid_size(request):
+    """
+    Generate invalid pool size(replicas).
+    """
+    return request.param
+
+@pytest.fixture(params=[2])
+def valid_minsize(request):
+    """
+    Generate valid min pool size(replicas).
+    """
+    return request.param
+
+@pytest.fixture(params=[128])
+def valid_pg_num(request):
+    """
+    Generate invalid pool pg number.
+    """
+    return request.param
+
+@pytest.fixture
+def valid_pool_name():
+    """
+    Generate valid pool name.
+    """
+    return pytest.config.getini("usm_pool_name")
+
+@pytest.fixture(params=[3])
+def valid_size(request):
+    """
+    Generate valid pool size(replicas).
+    """
+    return request.param

--- a/usmqe_tests/api/ceph/test_ceph_cluster.py
+++ b/usmqe_tests/api/ceph/test_ceph_cluster.py
@@ -2,6 +2,7 @@
 REST API test suite - ceph cluster import
 
 """
+from json.decoder import JSONDecodeError
 import pytest
 
 from usmqe.api.tendrlapi import cephapi
@@ -112,11 +113,16 @@ def test_cluster_import_valid(valid_session_credentials):
         section="parameters")
 
     LOGGER.debug("integration_id: %s" % integration_id)
-    pytest.check(
-        [x for x in api.get_cluster_list()
-         if x["integration_id"] == integration_id],
-        "Job list integration_id '{}' should be "
-        "present in cluster list.".format(integration_id),
-        issue="https://github.com/Tendrl/api/issues/154")
+    try:
+        pytest.check(
+            [x for x in api.get_cluster_list() if x.get("integration_id", "") == integration_id],
+            "Job list integration_id '{}' should be present in cluster \
+                     list.".format(integration_id),
+            issue="https://github.com/Tendrl/api/issues/154")
+    except JSONDecodeError:
+        pytest.check(False,
+                     "Job list integration_id '{}' should be present in cluster \
+                     list.".format(integration_id),
+                     issue="https://github.com/Tendrl/api/issues/166")
 
     # TODO add test case for checking imported machines

--- a/usmqe_tests/api/ceph/test_ceph_cluster.py
+++ b/usmqe_tests/api/ceph/test_ceph_cluster.py
@@ -117,7 +117,7 @@ def test_cluster_import_valid(valid_session_credentials):
         cl_list_id = [x for x in api.get_cluster_list()
                       if x.get("integration_id", "") == integration_id]
         pytest.check(
-            "There should be only on integration_id '{}'".format(integration_id),
+            "There should be only one integration_id '{}'".format(integration_id),
             len(cl_list_id) == 1)
         pytest.check(
             "Job list integration_id '{}' should be present in cluster list.".format(

--- a/usmqe_tests/api/ceph/test_ceph_cluster.py
+++ b/usmqe_tests/api/ceph/test_ceph_cluster.py
@@ -114,10 +114,15 @@ def test_cluster_import_valid(valid_session_credentials):
 
     LOGGER.debug("integration_id: %s" % integration_id)
     try:
+        cl_list_id = [x for x in api.get_cluster_list()
+                      if x.get("integration_id", "") == integration_id]
         pytest.check(
-            [x for x in api.get_cluster_list() if x.get("integration_id", "") == integration_id],
+            "There should be only on integration_id '{}'".format(integration_id),
+            len(cl_list_id) == 1)
+        pytest.check(
             "Job list integration_id '{}' should be present in cluster list.".format(
                 integration_id),
+            integration_id in cl_list_id,
             issue="https://github.com/Tendrl/api/issues/154")
     except JSONDecodeError:
         pytest.check(False,

--- a/usmqe_tests/api/ceph/test_ceph_cluster.py
+++ b/usmqe_tests/api/ceph/test_ceph_cluster.py
@@ -116,13 +116,13 @@ def test_cluster_import_valid(valid_session_credentials):
     try:
         pytest.check(
             [x for x in api.get_cluster_list() if x.get("integration_id", "") == integration_id],
-            "Job list integration_id '{}' should be present in cluster \
-                     list.".format(integration_id),
+            "Job list integration_id '{}' should be present in cluster list.".format(
+                integration_id),
             issue="https://github.com/Tendrl/api/issues/154")
     except JSONDecodeError:
         pytest.check(False,
-                     "Job list integration_id '{}' should be present in cluster \
-                     list.".format(integration_id),
+                     "Job list integration_id '{}' should be present in cluster list.".format(
+                        integration_id),
                      issue="https://github.com/Tendrl/api/issues/166")
 
     # TODO add test case for checking imported machines

--- a/usmqe_tests/api/ceph/test_pool.py
+++ b/usmqe_tests/api/ceph/test_pool.py
@@ -19,7 +19,6 @@ Teardown
 """
 
 
-
 # TODO create negative test case generator
 # http://doc.pytest.org/en/latest/parametrize.html#basic-pytest-generate-tests-example
 def test_create_pool_invalid(
@@ -43,15 +42,17 @@ def test_create_pool_invalid(
 
         .. test_step:: 1
 
-                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/CephCreatePool``
+                Connect to Tendrl API via POST request
+                to ``APIURL/:cluster_id/CephCreatePool``
                 Where cluster_id is set to predefined value.
 
         .. test_result:: 1
 
                 Server should return response in JSON format:
 
-                Return code should be **202** with data ``{"message": "Accepted"}``.
-                job should fail.
+                Return code should be **202** with data
+                ``{"message": "Accepted"}``.
+                Job should fail.
                 """
 
     api = cephapi.TendrlApiCeph(auth=valid_session_credentials)
@@ -87,14 +88,16 @@ def test_create_pool_valid(
 
         .. test_step:: 1
 
-                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/CephCreatePool``
+                Connect to Tendrl API via POST request
+                to ``APIURL/:cluster_id/CephCreatePool``
                 Where cluster_id is set to predefined value.
 
         .. test_result:: 1
 
                 Server should return response in JSON format:
 
-                Return code should be **202** with data ``{"message": "Accepted"}``.
+                Return code should be **202** with data
+                ``{"message": "Accepted"}``.
                 job should finish.
                 """
 
@@ -130,17 +133,18 @@ def test_create_pool_valid(
             There should be listed ceph pool named ``valid_pool_name``.
 
             """
-    #TODO get proper cluster name from configuration
+# TODO get proper cluster name from configuration
     storage = ceph_cluster.CephCluster(pytest.config.getini("usm_ceph_cl_name"))
     pools = storage.osd.pool_ls(detail=True)
     LOGGER.info("List of Ceph pools:{}".format(pools))
     selected_pools = [pool for pool in pools
                       if pool["pool_name"] == valid_pool_name
-                     ]
+                      ]
     pytest.check(len(selected_pools) == 1,
                  "Pool {} should be created in Ceph \
-                 cluster {}.".format(valid_pool_name, pytest.config.getini("usm_ceph_cl_name"))
-                )
+                 cluster {}.".format(valid_pool_name,
+                                     pytest.config.getini("usm_ceph_cl_name"))
+                 )
 
     """@pylatest api/ceph.create_pool_valid
         API-ceph: create_pool
@@ -157,7 +161,8 @@ def test_create_pool_valid(
 
         .. test_step:: 3
 
-            Connect to Tendrl API via GET request to ``APIURL/:cluster_id/CephPoolList``
+            Connect to Tendrl API via GET request
+            to ``APIURL/:cluster_id/CephPoolList``
             Where cluster_id is set to predefined value.
 
         .. test_result:: 3
@@ -171,21 +176,22 @@ def test_create_pool_valid(
         storage_pool_attributes = {
             "erasure_code_profile": pool["erasure_code_profile"],
             "min_size": pool["min_size"],
-            "percent_used": "0", # newly created pool
+            "percent_used": "0",  # newly created pool
             "pg_num": pool["pg_num"],
             "pool_id": pool["auid"],
             "pool_name": pool["pool_name"],
-            "quota_enabled": pool["quota_max_bytes"] == 0 and pool["quota_max_objects"] == 0,
+            "quota_enabled": pool["quota_max_bytes"] == 0 and
+                             pool["quota_max_objects"] == 0,
             "quota_max_bytes": pool["quota_max_bytes"],
             "quota_max_objects": pool["quota_max_objects"],
             "size": pool["size"],
-            "type": "replicated" if pool["type"] == 1 else "ecpool", #TODO
-            "used": "0" # newly created pool
+            "type": "replicated" if pool["type"] == 1 else "ecpool",  # TODO
+            "used": "0"  # newly created pool
             }
 
-        pool_tendrl = [pool for pool in api.get_pool_list(valid_cluster_id)
-                       if pool["pool_name"] == valid_pool_name
-                      ][0]
+        pool_tendrl = [pool_t for pool_t in api.get_pool_list(valid_cluster_id)
+                       if pool_t["pool_name"] == valid_pool_name
+                       ][0]
         # remove Tendrl specific keys
         pool_tendrl.pop("deleted")
         pool_tendrl.pop("hash")
@@ -198,7 +204,7 @@ def test_create_pool_valid(
             These should be the same.""".format(
                 pool_tendrl, storage_pool_attributes))
 
-## TODO This testcase is useless with current API because there is no 
+## TODO This testcase is useless with current API because there is no
 ## function to get pool according its name or ID
 #def test_read_pool_invalid(valid_cluster_id,
 #        invalid_pool_id,
@@ -230,6 +236,7 @@ def test_create_pool_valid(
 #
 #    pools = api.get_pool_list(valid_cluster_id)
 
+
 def test_update_pool_invalid(valid_cluster_id,
                              valid_pool_id,
                              valid_session_credentials,
@@ -237,7 +244,7 @@ def test_update_pool_invalid(valid_cluster_id,
                              invalid_size,
                              invalid_minsize,
                              invalid_pg_num):
-#TODO add quota support
+    # TODO add quota support
     """@pylatest api/ceph.update_pool_invalid
         API-ceph: update_pool
         ******************************
@@ -254,7 +261,8 @@ def test_update_pool_invalid(valid_cluster_id,
 
         .. test_step:: 1
 
-            Connect to Tendrl API via GET request to ``APIURL/:cluster_id/CephUpdatePool``
+            Connect to Tendrl API via GET request
+            to ``APIURL/:cluster_id/CephUpdatePool``
             Where cluster_id is set to predefined value.
 
         .. test_result:: 1
@@ -267,6 +275,7 @@ def test_update_pool_invalid(valid_cluster_id,
                              invalid_pool_name, invalid_size, invalid_minsize,
                              invalid_pg_num)["job_id"]
     api.wait_for_job_status(job_id, status="failed")
+
 
 def test_update_pool_name_valid(valid_cluster_id,
                                 valid_pool_id,
@@ -288,7 +297,8 @@ def test_update_pool_name_valid(valid_cluster_id,
 
         .. test_step:: 1
 
-            Connect to Tendrl API via GET request to ``APIURL/:cluster_id/CephUpdatePool``
+            Connect to Tendrl API via GET request
+            to ``APIURL/:cluster_id/CephUpdatePool``
             Where cluster_id is set to predefined value.
 
         .. test_result:: 1
@@ -325,12 +335,14 @@ def test_update_pool_name_valid(valid_cluster_id,
     LOGGER.info("List of Ceph pools:{}".format(pools))
     selected_pools = [pool for pool in pools
                       if pool["pool_name"] == valid_pool_name
-                     ]
+                      ]
     pytest.check(len(selected_pools) == 1,
                  "Pool {} should be updated in Ceph \
-                 cluster {}.".format(valid_pool_name, pytest.config.getini("usm_ceph_cl_name")),
+                 cluster {}.".format(valid_pool_name,
+                                     pytest.config.getini("usm_ceph_cl_name")),
                  issue="https://github.com/Tendrl/ceph-integration/issues/225"
-                )
+                 )
+
 
 def test_update_pool_valid(valid_cluster_id,
                            valid_pool_id,
@@ -339,7 +351,7 @@ def test_update_pool_valid(valid_cluster_id,
                            valid_size,
                            valid_minsize,
                            valid_pg_num):
-#TODO add quota support
+    # TODO add quota support
     """@pylatest api/ceph.update_pool_valid
         API-ceph: update_pool
         ******************************
@@ -356,7 +368,8 @@ def test_update_pool_valid(valid_cluster_id,
 
         .. test_step:: 1
 
-            Connect to Tendrl API via GET request to ``APIURL/:cluster_id/CephUpdatePool``
+            Connect to Tendrl API via GET request
+            to ``APIURL/:cluster_id/CephUpdatePool``
             Where cluster_id is set to predefined value.
 
         .. test_result:: 1
@@ -397,12 +410,13 @@ def test_update_pool_valid(valid_cluster_id,
     LOGGER.info("List of Ceph pools:{}".format(pools))
     selected_pools = [pool for pool in pools
                       if pool["pool_name"] == valid_pool_name
-                     ]
+                      ]
     pytest.check(len(selected_pools) == 1,
                  "Pool {} should be updated in Ceph \
-                 cluster {}.".format(valid_pool_name, pytest.config.getini("usm_ceph_cl_name")),
+                 cluster {}.".format(valid_pool_name,
+                                     pytest.config.getini("usm_ceph_cl_name")),
                  issue="https://github.com/Tendrl/ceph-integration/issues/225"
-                )
+                 )
 
     """@pylatest api/ceph.update_pool_valid
         API-ceph: update_pool
@@ -419,7 +433,8 @@ def test_update_pool_valid(valid_cluster_id,
 
         .. test_step:: 3
 
-            Connect to Tendrl API via GET request to ``APIURL/:cluster_id/CephPoolList``
+            Connect to Tendrl API via GET request
+            to ``APIURL/:cluster_id/CephPoolList``
             Where cluster_id is set to predefined value.
 
         .. test_result:: 3
@@ -433,21 +448,22 @@ def test_update_pool_valid(valid_cluster_id,
         storage_pool_attributes = {
             "erasure_code_profile": pool["erasure_code_profile"],
             "min_size": pool["min_size"],
-            "percent_used": "0", # newly created pool
+            "percent_used": "0",  # newly created pool
             "pg_num": pool["pg_num"],
             "pool_id": pool["auid"],
             "pool_name": pool["pool_name"],
-            "quota_enabled": pool["quota_max_bytes"] == 0 and pool["quota_max_objects"] == 0,
+            "quota_enabled": pool["quota_max_bytes"] == 0 and
+                             pool["quota_max_objects"] == 0,
             "quota_max_bytes": pool["quota_max_bytes"],
             "quota_max_objects": pool["quota_max_objects"],
             "size": pool["size"],
-            "type": "replicated" if pool["type"] == 1 else "ecpool", #TODO
-            "used": "0" # newly created pool
+            "type": "replicated" if pool["type"] == 1 else "ecpool",  # TODO
+            "used": "0"  # newly created pool
             }
 
-        pool_tendrl = [pool for pool in api.get_pool_list(valid_cluster_id)
-                       if pool["pool_name"] == valid_pool_name
-                      ][0]
+        pool_tendrl = [pool_t for pool_t in api.get_pool_list(valid_cluster_id)
+                       if pool_t["pool_name"] == valid_pool_name
+                       ][0]
         # remove Tendrl specific keys
         pool_tendrl.pop("deleted")
         pool_tendrl.pop("hash")
@@ -459,6 +475,7 @@ def test_update_pool_valid(valid_cluster_id,
             Tendrl pool attributes: {}
             These should be the same.""".format(
                 pool_tendrl, storage_pool_attributes))
+
 
 def test_delete_pool_invalid(
         valid_cluster_id,
@@ -480,7 +497,8 @@ def test_delete_pool_invalid(
 
         .. test_step:: 1
 
-                Connect to Tendrl API via DELETE request to ``APIURL/:cluster_id/CephDeletePool``
+                Connect to Tendrl API via DELETE request
+                to ``APIURL/:cluster_id/CephDeletePool``
                 Where cluster_id is set to predefined value.
 
         .. test_result:: 1
@@ -493,9 +511,7 @@ def test_delete_pool_invalid(
 
     api = cephapi.TendrlApiCeph(auth=valid_session_credentials)
     job_id = api.delete_pool(valid_cluster_id, invalid_pool_id)["job_id"]
-    api.wait_for_job_status(
-        job_id,
-        status="failed")
+    api.wait_for_job_status(job_id, status="failed")
 
 
 def test_delete_pool_valid(
@@ -519,7 +535,8 @@ def test_delete_pool_valid(
 
         .. test_step:: 1
 
-                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/CephDeletePool``
+                Connect to Tendrl API via POST request
+                to ``APIURL/:cluster_id/CephDeletePool``
                 Where cluster_id is set to predefined value.
 
         .. test_result:: 1
@@ -559,10 +576,10 @@ def test_delete_pool_valid(
             """
     storage = ceph_cluster.CephCluster(pytest.config.getini("usm_ceph_cl_name"))
 
-    pytest.check(not valid_pool_name in storage.osd.pool_ls(),
+    pytest.check(valid_pool_name not in storage.osd.pool_ls(),
                  "Pool {} should not be in Ceph \
                  cluster {} after deletion.".format(
                      valid_pool_name,
                      pytest.config.getini("usm_ceph_cl_name")),
                  issue="https://github.com/Tendrl/ceph-integration/issues/224"
-                )
+                 )

--- a/usmqe_tests/api/ceph/test_pool.py
+++ b/usmqe_tests/api/ceph/test_pool.py
@@ -180,8 +180,9 @@ def test_create_pool_valid(
             "pg_num": pool["pg_num"],
             "pool_id": pool["auid"],
             "pool_name": pool["pool_name"],
-            "quota_enabled": pool["quota_max_bytes"] == 0 and
-                             pool["quota_max_objects"] == 0,
+            "quota_enabled":
+                pool["quota_max_bytes"] == 0 and
+                pool["quota_max_objects"] == 0,
             "quota_max_bytes": pool["quota_max_bytes"],
             "quota_max_objects": pool["quota_max_objects"],
             "size": pool["size"],
@@ -204,37 +205,37 @@ def test_create_pool_valid(
             These should be the same.""".format(
                 pool_tendrl, storage_pool_attributes))
 
-## TODO This testcase is useless with current API because there is no
-## function to get pool according its name or ID
-#def test_read_pool_invalid(valid_cluster_id,
-#        invalid_pool_id,
-#        valid_session_credentials):
-#    """@pylatest api/ceph.read_pool_invalid
-#        API-ceph: read_pool
-#        ******************************
+# # TODO This testcase is useless with current API because there is no
+# # function to get pool according its name or ID
+# def test_read_pool_invalid(valid_cluster_id,
+#         invalid_pool_id,
+#         valid_session_credentials):
+#     """@pylatest api/ceph.read_pool_invalid
+#         API-ceph: read_pool
+#         ******************************
 #
-#        :authors:
-#            - fbalak@redhat.com
-#            - mkudlej@redhat.com
+#         :authors:
+#             - fbalak@redhat.com
+#             - mkudlej@redhat.com
 #
-#        Description
-#        ===========
-#        Negative Read from CRUD for pools.
+#         Description
+#         ===========
+#         Negative Read from CRUD for pools.
 #
-#        Check if there is not pool in Ceph cluster via API.
+#         Check if there is not pool in Ceph cluster via API.
 #
-#        .. test_step:: 1
+#         .. test_step:: 1
 #
-#            Connect to Tendrl API via GET request to ``APIURL/:cluster_id/CephPoolList``
-#            Where cluster_id is set to predefined value.
+#             Connect to Tendrl API via GET request to ``APIURL/:cluster_id/CephPoolList``
+#             Where cluster_id is set to predefined value.
 #
-#        .. test_result:: 1
+#         .. test_result:: 1
 #
-#            There should not be listed ceph pool named ``invalid_pool_name``.
+#             There should not be listed ceph pool named ``invalid_pool_name``.
 #
-#            """
+#             """
 #
-#    pools = api.get_pool_list(valid_cluster_id)
+#     pools = api.get_pool_list(valid_cluster_id)
 
 
 def test_update_pool_invalid(valid_cluster_id,
@@ -452,8 +453,9 @@ def test_update_pool_valid(valid_cluster_id,
             "pg_num": pool["pg_num"],
             "pool_id": pool["auid"],
             "pool_name": pool["pool_name"],
-            "quota_enabled": pool["quota_max_bytes"] == 0 and
-                             pool["quota_max_objects"] == 0,
+            "quota_enabled":
+                pool["quota_max_bytes"] == 0 and
+                pool["quota_max_objects"] == 0,
             "quota_max_bytes": pool["quota_max_bytes"],
             "quota_max_objects": pool["quota_max_objects"],
             "size": pool["size"],

--- a/usmqe_tests/api/ceph/test_pool.py
+++ b/usmqe_tests/api/ceph/test_pool.py
@@ -201,8 +201,8 @@ def test_create_pool_valid(
 
         pytest.check(
             pool_tendrl == storage_pool_attributes,
-            "Storage pool attributes: {}"
-            "Tendrl pool attributes: {}"
+            "Storage pool attributes: {} "
+            "Tendrl pool attributes: {} "
             "These should be the same.".format(
                 pool_tendrl, storage_pool_attributes))
 
@@ -474,9 +474,9 @@ def test_update_pool_valid(valid_cluster_id,
 
         pytest.check(
             pool_tendrl == storage_pool_attributes,
-            """Storage pool attributes: {}
-            Tendrl pool attributes: {}
-            These should be the same.""".format(
+            "Storage pool attributes: {} "
+            "Tendrl pool attributes: {} "
+            "These should be the same.".format(
                 pool_tendrl, storage_pool_attributes))
 
 

--- a/usmqe_tests/api/ceph/test_pool.py
+++ b/usmqe_tests/api/ceph/test_pool.py
@@ -201,9 +201,9 @@ def test_create_pool_valid(
 
         pytest.check(
             pool_tendrl == storage_pool_attributes,
-            """Storage pool attributes: {}
-            Tendrl pool attributes: {}
-            These should be the same.""".format(
+            "Storage pool attributes: {}"
+            "Tendrl pool attributes: {}"
+            "These should be the same.".format(
                 pool_tendrl, storage_pool_attributes))
 
 # # TODO This testcase is useless with current API because there is no

--- a/usmqe_tests/api/ceph/test_pool.py
+++ b/usmqe_tests/api/ceph/test_pool.py
@@ -1,0 +1,533 @@
+"""
+REST API test suite - Ceph pool
+"""
+import pytest
+
+from usmqe.api.tendrlapi import cephapi
+from usmqe.ceph import ceph
+
+LOGGER = pytest.get_logger('test_pool', module=True)
+"""@pylatest default
+Setup
+=====
+There is Ceph cluster where pools can be managed.
+"""
+
+"""@pylatest default
+Teardown
+========
+"""
+
+
+
+# TODO create negative test case generator
+# http://doc.pytest.org/en/latest/parametrize.html#basic-pytest-generate-tests-example
+def test_create_pool_invalid(
+        valid_cluster_id,
+        invalid_pool_name,
+        invalid_pg_num,
+        invalid_minsize,
+        invalid_size,
+        valid_session_credentials):
+    """@pylatest api/ceph.create_pool_invalid
+        API-ceph: create_volume
+        ******************************
+
+        :authors:
+            - fbalak@redhat.com
+            - mkudlej@redhat.com
+
+        Description
+        ===========
+
+        .. test_step:: 1
+
+                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/CephCreatePool``
+                Where cluster_id is set to predefined value.
+
+        .. test_result:: 1
+
+                Server should return response in JSON format:
+
+                Return code should be **202** with data ``{"message": "Accepted"}``.
+                job should fail.
+                """
+
+    api = cephapi.TendrlApiCeph(auth=valid_session_credentials)
+
+    job_id = api.create_pool(valid_cluster_id,
+                             invalid_pool_name,
+                             invalid_pg_num,
+                             invalid_minsize,
+                             invalid_size)["job_id"]
+    # TODO check correctly server response or etcd job status
+    api.wait_for_job_status(
+        job_id,
+        status="failed",
+        issue="https://github.com/Tendrl/tendrl-api/issues/33")
+
+
+def test_create_pool_valid(
+        valid_cluster_id,
+        valid_pool_name,
+        valid_pg_num,
+        valid_minsize,
+        valid_size,
+        valid_session_credentials):
+    """@pylatest api/ceph.create_pool_valid
+        API-ceph: create_pool
+        ******************************
+
+        :authors:
+            - fbalak@redhat.com
+            - mkudlej@redhat.com
+
+        Description
+        ===========
+
+        .. test_step:: 1
+
+                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/CephCreatePool``
+                Where cluster_id is set to predefined value.
+
+        .. test_result:: 1
+
+                Server should return response in JSON format:
+
+                Return code should be **202** with data ``{"message": "Accepted"}``.
+                job should finish.
+                """
+
+    api = cephapi.TendrlApiCeph(auth=valid_session_credentials)
+
+    job_id = api.create_volume(valid_cluster_id,
+                               valid_pool_name,
+                               valid_pg_num,
+                               valid_minsize,
+                               valid_size)["job_id"]
+    api.wait_for_job_status(job_id)
+    """@pylatest api/ceph.create_pool
+        API-ceph: create_pool
+        ******************************
+
+        :authors:
+            - fbalak@redhat.com
+            - mkudlej@redhat.com
+
+        Description
+        ===========
+
+        Check if there is created pool in ceph cluster via CLI.
+
+        .. test_step:: 2
+
+            Connect to ceph monitor machine via ssh and run
+            ``ceph --cluster *clustername* pool status``
+
+        .. test_result:: 2
+
+            There should be listed ceph pool named ``test_name``.
+
+            """
+    #TODO get proper cluster name from configuration
+    storage = ceph.CephCluster("test_name")
+    pools = [pool for pool in storage.mon.pool_ls(detail=True)
+             if pool["poolname"] == valid_pool_name
+            ]
+    pytest.check(len(pools) == 1,
+                 "Pool {} should be created in Ceph \
+                 cluster {}.".format(valid_pool_name, "test_name")
+                )
+
+    """@pylatest api/ceph.create_pool
+        API-ceph: create_pool
+        ******************************
+
+        :authors:
+            - fbalak@redhat.com
+            - mkudlej@redhat.com
+
+        Description
+        ===========
+
+        Check if there is created pool in ceph cluster via API.
+
+        .. test_step:: 3
+
+            Connect to Tendrl API via GET request to ``APIURL/:cluster_id/CephPoolList``
+            Where cluster_id is set to predefined value.
+
+        .. test_result:: 3
+
+            There should be listed ceph pool named ``test_name``.
+
+            """
+#ceph --format json --cluster test_name osd pool ls detail
+#    "auid":0,
+#    "cache_min_evict_age":0
+#    "cache_min_flush_age":0
+#    "cache_mode":"none"
+#    "cache_target_dirty_high_ratio_micro":0
+#    "cache_target_dirty_ratio_micro":0
+#    "cache_target_full_ratio_micro":0
+#    "crash_replay_interval":0,
+#    "crush_ruleset":0,
+#    "erasure_code_profile":""
+#    "expected_num_objects":0
+#    "fast_read":false
+#    "flags":1,
+#    "flags_names":"hashpspool",
+#    "grade_table":[]
+#    "hit_set_count":0
+#    "hit_set_grade_decay_rate":0
+#    "hit_set_params":{"type":"none"}
+#    "hit_set_period":0
+#    "hit_set_search_last_n":0
+#    "last_change":"1",
+#    "last_force_op_resend":"0",
+#    "min_read_recency_for_promote":0
+#    "min_size":2,
+#    "min_write_recency_for_promote":0
+#    "object_hash":2,
+#    "options":{}
+#    "pg_num":64,
+#    "pg_placement_num":64,
+#    "pool_name":"rbd",
+#    "pool_snaps":[]
+#    "quota_max_bytes":0
+#    "quota_max_objects":0
+#    "read_tier":-1
+#    "removed_snaps":"[]"
+#    "size":3,
+#    "snap_epoch":0
+#    "snap_mode":"selfmanaged",
+#    "snap_seq":0,
+#    "stripe_width":0
+#    "target_max_bytes":0
+#    "target_max_objects":0
+#    "tier_of":-1
+#    "tiers":[]
+#    "type":1,
+#    "use_gmt_hitset":true
+#    "write_tier":-1
+
+    if len(pools) == 1:
+        pool = pools[0]
+        storage_pool_attributes = {
+            "erasure_code_profile": pool["erasure_code_profile"],
+            "min_size": pool["min_size"],
+            "percent_used": "0", # newly created pool
+            "pg_num": pool["pg_num"],
+            "pool_id": pool["auid"],
+            "pool_name": pool["pool_name"],
+            "quota_enabled": pool["quota_max_bytes"] == 0 and pool["quota_max_objects"] == 0,
+            "quota_max_bytes": pool["quota_max_bytes"],
+            "quota_max_objects": pool["quota_max_objects"],
+            "size": pool["size"],
+            "type": "replicated" if pool["type"] == 1 else "ecpool", #TODO
+            "used": "0" # newly created pool
+            }
+
+        pool_tendrl = [pool for pool in api.get_pool_list(valid_cluster_id)
+                       if pool["pool_name"] == valid_pool_name
+                      ][0]
+        # remove Tendrl specific keys
+        pool_tendrl.pop("deleted")
+        pool_tendrl.pop("hash")
+        pool_tendrl.pop("updated_at")
+
+        pytest.check(
+            pool_tendrl == storage_pool_attributes,
+            """Storage pool attributes: {}
+            Tendrl pool attributes: {}
+            These should be the same.""".format(
+                pool_tendrl, storage_pool_attributes))
+
+
+#def test_stop_volume_invalid(
+#        valid_cluster_id,
+#        invalid_volume_name,
+#        valid_session_credentials):
+#    """@pylatest api/ceph.stop_volume_invalid
+#        API-ceph: stop_volume
+#        ******************************
+#
+#        .. test_metadata:: author fbalak@redhat.com
+#
+#        Description
+#        ===========
+#
+#        Try to stop volume with given name and cluster id via API.
+#
+#        .. test_step:: 1
+#
+#                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterStopVolume``
+#                Where cluster_id is set to predefined value.
+#
+#        .. test_result:: 1
+#
+#                Server should return response in JSON format:
+#
+#                Return code should be **202** with data ``{"message": "Accepted"}``.
+#                Job should fail.
+#                """
+#
+#    api = cephapi.TendrlApiGluster(auth=valid_session_credentials)
+#    volume_data = {
+#        "Volume.volname": invalid_volume_name,
+#    }
+#
+#    job_id = api.stop_volume(valid_cluster_id, volume_data)["job_id"]
+#    # TODO check correctly server response or etcd job status
+#    api.wait_for_job_status(
+#            job_id,
+#            status="failed",
+#            issue="https://github.com/Tendrl/tendrl-api/issues/33")
+#
+#
+#def test_stop_volume_valid(
+#        valid_cluster_id,
+#        valid_volume_name,
+#        valid_volume_id,
+#        valid_session_credentials):
+#    """@pylatest api/ceph.stop_volume_valid
+#        API-ceph: stop_volume
+#        ******************************
+#
+#        .. test_metadata:: author fbalak@redhat.com
+#
+#        Description
+#        ===========
+#
+#        Try to stop volume with given name and cluster id via API.
+#
+#        .. test_step:: 1
+#
+#                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterStopVolume``
+#                Where cluster_id is set to predefined value.
+#
+#        .. test_result:: 1
+#
+#                Server should return response in JSON format:
+#
+#                Return code should be **202** with data ``{"message": "Accepted"}``.
+#                job should finish.
+#                """
+#
+#    api = cephapi.TendrlApiGluster(auth=valid_session_credentials)
+#    volume_data = {
+#        "Volume.volname": valid_volume_name,
+#    }
+#
+#    job_id = api.stop_volume(valid_cluster_id, volume_data)["job_id"]
+#    api.wait_for_job_status(job_id)
+#    volume = ceph.GlusterVolume(valid_volume_name)
+#    volume.check_status("Stopped")
+#    status = api.get_volume_list(valid_cluster_id)[0][valid_volume_id]["status"]
+#    pytest.check(
+#        status == "Stopped",
+#        "Status from API is {}, should be 'Stopped'".format(status),
+#        issue="https://github.com/Tendrl/tendrl-api/issues/56")
+#
+#
+## TODO create negative test case generator
+## http://doc.pytest.org/en/latest/parametrize.html#basic-pytest-generate-tests-example
+#def test_start_volume_invalid(
+#        valid_cluster_id,
+#        invalid_volume_name,
+#        valid_session_credentials):
+#    """@pylatest api/ceph.start_volume_invalid
+#        API-ceph: start_volume
+#        ******************************
+#
+#        .. test_metadata:: author fbalak@redhat.com
+#
+#        Description
+#        ===========
+#
+#        Try to start volume with given name and cluster id via API.
+#
+#        .. test_step:: 1
+#
+#                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterStartVolume``
+#                Where cluster_id is set to predefined value.
+#
+#        .. test_result:: 1
+#
+#                Server should return response in JSON format:
+#
+#                Return code should be **202** with data ``{"message": "Accepted"}``.
+#                job should fail.
+#                """
+#
+#    api = cephapi.TendrlApiGluster(auth=valid_session_credentials)
+#    volume_data = {
+#        "Volume.volname": invalid_volume_name
+#    }
+#
+#    job_id = api.start_volume(valid_cluster_id, volume_data)["job_id"]
+#    # TODO check correctly server response or etcd job status
+#    api.wait_for_job_status(
+#        job_id,
+#        status="failed",
+#        issue="https://github.com/Tendrl/tendrl-api/issues/33")
+#
+#
+#def test_start_volume_valid(
+#        valid_cluster_id,
+#        valid_volume_name,
+#        valid_volume_id,
+#        valid_session_credentials):
+#    """@pylatest api/ceph.start_volume_valid
+#        API-ceph: start_volume
+#        ******************************
+#
+#        .. test_metadata:: author fbalak@redhat.com
+#
+#        Description
+#        ===========
+#
+#        Try to start volume with given name and cluster id via API.
+#
+#        .. test_step:: 1
+#
+#                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterStartVolume``
+#                Where cluster_id is set to predefined value.
+#
+#        .. test_result:: 1
+#
+#                Server should return response in JSON format:
+#
+#                Return code should be **202** with data ``{"message": "Accepted"}``.
+#                job should finish.
+#                """
+#
+#    api = cephapi.TendrlApiGluster(auth=valid_session_credentials)
+#    volume_data = {
+#        "Volume.volname": valid_volume_name,
+#    }
+#
+#    job_id = api.start_volume(valid_cluster_id, volume_data)["job_id"]
+#    api.wait_for_job_status(job_id)
+#    volume = ceph.GlusterVolume(valid_volume_name)
+#    volume.check_status("Started")
+#    status = api.get_volume_list(valid_cluster_id)[0][valid_volume_id]["status"]
+#    pytest.check(
+#        status == "Started",
+#        "Status from API is {}, should be 'Started'".format(status),
+#        issue="https://github.com/Tendrl/tendrl-api/issues/55")
+#
+#
+#def test_delete_volume_invalid(
+#        valid_cluster_id,
+#        invalid_volume_id,
+#        valid_session_credentials):
+#    """@pylatest api/ceph.delete_volume
+#        API-ceph: delete_volume
+#        ******************************
+#
+#        .. test_metadata:: author fbalak@redhat.com
+#
+#        Description
+#        ===========
+#
+#        Delete ceph volume ``Vol_test`` via API.
+#
+#        .. test_step:: 1
+#
+#                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterDeleteVolume``
+#                Where cluster_id is set to predefined value.
+#
+#        .. test_result:: 1
+#
+#                Server should return response in JSON format:
+#
+#                Return code should be **202** with data ``{"message": "Accepted"}``.
+#                job should fail.
+#                """
+#
+#    api = cephapi.TendrlApiGluster(auth=valid_session_credentials)
+#    volume_data = {
+#        "Volume.volname": valid_cluster_id,
+#        "Volume.vol_id": invalid_volume_id
+#    }
+#
+#    job_id = api.delete_volume(valid_cluster_id, volume_data)["job_id"]
+#    # TODO check correctly server response or etcd job status
+#    api.wait_for_job_status(
+#            job_id,
+#            status="failed",
+#            issue="https://github.com/Tendrl/tendrl-api/issues/33")
+#
+#
+#def test_delete_volume_valid(
+#        valid_cluster_id,
+#        valid_volume_name,
+#        valid_volume_id,
+#        valid_session_credentials):
+#    """@pylatest api/ceph.delete_volume
+#        API-ceph: delete_volume
+#        ******************************
+#
+#        .. test_metadata:: author fbalak@redhat.com
+#
+#        Description
+#        ===========
+#
+#        Delete ceph volume ``Vol_test`` via API.
+#
+#        .. test_step:: 1
+#
+#                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterDeleteVolume``
+#                Where cluster_id is set to predefined value.
+#
+#        .. test_result:: 1
+#
+#                Server should return response in JSON format:
+#
+#                Return code should be **202** with data ``{"message": "Accepted"}``.
+#                job should finish.
+#                """
+#
+#    api = cephapi.TendrlApiGluster(auth=valid_session_credentials)
+#    volume_data = {
+#        "Volume.volname": valid_volume_name,
+#        "Volume.vol_id": valid_volume_id
+#    }
+#
+#    job_id = api.delete_volume(valid_cluster_id, volume_data)["job_id"]
+#    api.wait_for_job_status(
+#        job_id,
+#        issue="https://github.com/Tendrl/api/issues/33")
+#    """@pylatest api/ceph.create_volume
+#        API-ceph: create_volume
+#        ******************************
+#
+#        .. test_metadata:: author fbalak@redhat.com
+#
+#        Description
+#        ===========
+#
+#        Check if there is created volume on ceph nodes via CLI.
+#
+#        .. test_step:: 1
+#
+#            Connect to ceph node machine via ssh and run
+#            ``ceph volume info command``
+#
+#        .. test_result:: 1
+#
+#            There should be listed ceph volume named ``Vol_test``.
+#
+#            """
+#    storage = ceph.GlusterCommon()
+#    storage.find_volume_name(valid_volume_name, False)
+#
+#    # There should be either deleted attribute or record should be removed from database
+#    # https://github.com/Tendrl/api/issues/78
+#    #
+#    # deleted = api.get_volume_list(valid_cluster_id)[0][valid_volume_id]["deleted"]
+#    # pytest.check(
+#    #     deleted == "True",
+#    #     "deleted attribute should be True, is {}".format(deleted),
+#    #     issue="https://github.com/Tendrl/tendrl-api/issues/33")

--- a/usmqe_tests/api/gluster/test_volume.py
+++ b/usmqe_tests/api/gluster/test_volume.py
@@ -35,17 +35,14 @@ def test_create_volume_invalid(
         Description
         ===========
 
-        Get list of attributes needed to use in cluster volume creation
-        with given cluster_id.
+        Get list of attributes needed to use in cluster volume creation with given cluster_id.
 
         .. test_step:: 1
 
-                Connect to Tendrl API via POST request
-                to ``APIURL/:cluster_id/GlusterCreateVolume``
+                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterCreateVolume``
                 Where cluster_id is set to predefined value.
 
-                When some attribute is set to None then in request json is set
-                to ``null``.
+                When some attribute is set to None then in request json is set to ``null``.
                 e.g. {
                     "Volume.replica_count": "2",
                     "Volume.bricks": null,
@@ -66,9 +63,10 @@ def test_create_volume_invalid(
         valid_cluster_id,
         invalid_volume_configuration)["job_id"]
     # TODO check correctly server response or etcd job status
-    api.wait_for_job_status(job_id,
-                            status="failed",
-                            issue="https://github.com/Tendrl/tendrl-api/issues/33")
+    api.wait_for_job_status(
+            job_id,
+            status="failed",
+            issue="https://github.com/Tendrl/tendrl-api/issues/33")
 
 
 def test_create_volume_valid(
@@ -85,13 +83,11 @@ def test_create_volume_valid(
         Description
         ===========
 
-        Get list of attributes needed to use in cluster volume creation
-        with given cluster_id.
+        Get list of attributes needed to use in cluster volume creation with given cluster_id.
 
         .. test_step:: 1
 
-                Connect to Tendrl API via POST request
-                to ``APIURL/:cluster_id/GlusterCreateVolume``
+                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterCreateVolume``
                 Where cluster_id is set to predefined value.
 
         .. test_result:: 1
@@ -134,24 +130,26 @@ def test_create_volume_valid(
 
     volume = gluster.GlusterVolume(valid_volume_name)
     volume_id = volume.get_volume_id()
-    storage_volume_attributes = {"name": volume.name,
-                                 "id": volume.id,
-                                 "status": volume.status,
-                                 "stripe_count": volume.stripe_count,
-                                 "replica_count": volume.replica_count,
-                                 "brick_count": volume.brick_count,
-                                 "snapshot_count": volume.snap_count
-                                 }
+    storage_volume_attributes = {
+            "name": volume.name,
+            "id": volume.id,
+            "status": volume.status,
+            "stripe_count": volume.stripe_count,
+            "replica_count": volume.replica_count,
+            "brick_count": volume.brick_count,
+            "snapshot_count": volume.snap_count
+        }
 
     volume_tendrl = api.get_volume_list(valid_cluster_id)[0][volume_id]
-    tendrl_volume_attributes = {"name": volume_tendrl["name"],
-                                "id": volume_tendrl["vol_id"],
-                                "status": volume_tendrl["status"],
-                                "stripe_count": volume_tendrl["stripe_count"],
-                                "replica_count": volume_tendrl["replica_count"],
-                                "brick_count": volume_tendrl["brick_count"],
-                                "snapshot_count": volume_tendrl["snap_count"]
-                                }
+    tendrl_volume_attributes = {
+            "name": volume_tendrl["name"],
+            "id": volume_tendrl["vol_id"],
+            "status": volume_tendrl["status"],
+            "stripe_count": volume_tendrl["stripe_count"],
+            "replica_count": volume_tendrl["replica_count"],
+            "brick_count": volume_tendrl["brick_count"],
+            "snapshot_count": volume_tendrl["snap_count"]
+        }
     pytest.check(
         tendrl_volume_attributes == storage_volume_attributes,
         """Storage volume attributes: {}
@@ -177,8 +175,7 @@ def test_stop_volume_invalid(
 
         .. test_step:: 1
 
-                Connect to Tendrl API via POST request
-                to ``APIURL/:cluster_id/GlusterStopVolume``
+                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterStopVolume``
                 Where cluster_id is set to predefined value.
 
         .. test_result:: 1
@@ -196,9 +193,10 @@ def test_stop_volume_invalid(
 
     job_id = api.stop_volume(valid_cluster_id, volume_data)["job_id"]
     # TODO check correctly server response or etcd job status
-    api.wait_for_job_status(job_id,
-                            status="failed",
-                            issue="https://github.com/Tendrl/tendrl-api/issues/33")
+    api.wait_for_job_status(
+            job_id,
+            status="failed",
+            issue="https://github.com/Tendrl/tendrl-api/issues/33")
 
 
 def test_stop_volume_valid(
@@ -219,8 +217,7 @@ def test_stop_volume_valid(
 
         .. test_step:: 1
 
-                Connect to Tendrl API via POST request
-                to ``APIURL/:cluster_id/GlusterStopVolume``
+                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterStopVolume``
                 Where cluster_id is set to predefined value.
 
         .. test_result:: 1
@@ -268,8 +265,7 @@ def test_start_volume_invalid(
 
         .. test_step:: 1
 
-                Connect to Tendrl API via POST request
-                to ``APIURL/:cluster_id/GlusterStartVolume``
+                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterStartVolume``
                 Where cluster_id is set to predefined value.
 
         .. test_result:: 1
@@ -311,8 +307,7 @@ def test_start_volume_valid(
 
         .. test_step:: 1
 
-                Connect to Tendrl API via POST request
-                to ``APIURL/:cluster_id/GlusterStartVolume``
+                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterStartVolume``
                 Where cluster_id is set to predefined value.
 
         .. test_result:: 1
@@ -357,8 +352,7 @@ def test_delete_volume_invalid(
 
         .. test_step:: 1
 
-                Connect to Tendrl API via POST request
-                to ``APIURL/:cluster_id/GlusterDeleteVolume``
+                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterDeleteVolume``
                 Where cluster_id is set to predefined value.
 
         .. test_result:: 1
@@ -377,9 +371,10 @@ def test_delete_volume_invalid(
 
     job_id = api.delete_volume(valid_cluster_id, volume_data)["job_id"]
     # TODO check correctly server response or etcd job status
-    api.wait_for_job_status(job_id,
-                            status="failed",
-                            issue="https://github.com/Tendrl/tendrl-api/issues/33")
+    api.wait_for_job_status(
+            job_id,
+            status="failed",
+            issue="https://github.com/Tendrl/tendrl-api/issues/33")
 
 
 def test_delete_volume_valid(
@@ -400,8 +395,7 @@ def test_delete_volume_valid(
 
         .. test_step:: 1
 
-                Connect to Tendrl API via POST request
-                to ``APIURL/:cluster_id/GlusterDeleteVolume``
+                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterDeleteVolume``
                 Where cluster_id is set to predefined value.
 
         .. test_result:: 1

--- a/usmqe_tests/api/gluster/test_volume.py
+++ b/usmqe_tests/api/gluster/test_volume.py
@@ -35,14 +35,17 @@ def test_create_volume_invalid(
         Description
         ===========
 
-        Get list of attributes needed to use in cluster volume creation with given cluster_id.
+        Get list of attributes needed to use in cluster volume creation
+        with given cluster_id.
 
         .. test_step:: 1
 
-                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterCreateVolume``
+                Connect to Tendrl API via POST request
+                to ``APIURL/:cluster_id/GlusterCreateVolume``
                 Where cluster_id is set to predefined value.
 
-                When some attribute is set to None then in request json is set to ``null``.
+                When some attribute is set to None then in request json is set
+                to ``null``.
                 e.g. {
                     "Volume.replica_count": "2",
                     "Volume.bricks": null,
@@ -63,10 +66,9 @@ def test_create_volume_invalid(
         valid_cluster_id,
         invalid_volume_configuration)["job_id"]
     # TODO check correctly server response or etcd job status
-    api.wait_for_job_status(
-            job_id,
-            status="failed",
-            issue="https://github.com/Tendrl/tendrl-api/issues/33")
+    api.wait_for_job_status(job_id,
+                            status="failed",
+                            issue="https://github.com/Tendrl/tendrl-api/issues/33")
 
 
 def test_create_volume_valid(
@@ -83,11 +85,13 @@ def test_create_volume_valid(
         Description
         ===========
 
-        Get list of attributes needed to use in cluster volume creation with given cluster_id.
+        Get list of attributes needed to use in cluster volume creation
+        with given cluster_id.
 
         .. test_step:: 1
 
-                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterCreateVolume``
+                Connect to Tendrl API via POST request
+                to ``APIURL/:cluster_id/GlusterCreateVolume``
                 Where cluster_id is set to predefined value.
 
         .. test_result:: 1
@@ -130,26 +134,24 @@ def test_create_volume_valid(
 
     volume = gluster.GlusterVolume(valid_volume_name)
     volume_id = volume.get_volume_id()
-    storage_volume_attributes = {
-            "name": volume.name,
-            "id": volume.id,
-            "status": volume.status,
-            "stripe_count": volume.stripe_count,
-            "replica_count": volume.replica_count,
-            "brick_count": volume.brick_count,
-            "snapshot_count": volume.snap_count
-        }
+    storage_volume_attributes = {"name": volume.name,
+                                 "id": volume.id,
+                                 "status": volume.status,
+                                 "stripe_count": volume.stripe_count,
+                                 "replica_count": volume.replica_count,
+                                 "brick_count": volume.brick_count,
+                                 "snapshot_count": volume.snap_count
+                                 }
 
     volume_tendrl = api.get_volume_list(valid_cluster_id)[0][volume_id]
-    tendrl_volume_attributes = {
-            "name": volume_tendrl["name"],
-            "id": volume_tendrl["vol_id"],
-            "status": volume_tendrl["status"],
-            "stripe_count": volume_tendrl["stripe_count"],
-            "replica_count": volume_tendrl["replica_count"],
-            "brick_count": volume_tendrl["brick_count"],
-            "snapshot_count": volume_tendrl["snap_count"]
-        }
+    tendrl_volume_attributes = {"name": volume_tendrl["name"],
+                                "id": volume_tendrl["vol_id"],
+                                "status": volume_tendrl["status"],
+                                "stripe_count": volume_tendrl["stripe_count"],
+                                "replica_count": volume_tendrl["replica_count"],
+                                "brick_count": volume_tendrl["brick_count"],
+                                "snapshot_count": volume_tendrl["snap_count"]
+                                }
     pytest.check(
         tendrl_volume_attributes == storage_volume_attributes,
         """Storage volume attributes: {}
@@ -175,7 +177,8 @@ def test_stop_volume_invalid(
 
         .. test_step:: 1
 
-                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterStopVolume``
+                Connect to Tendrl API via POST request
+                to ``APIURL/:cluster_id/GlusterStopVolume``
                 Where cluster_id is set to predefined value.
 
         .. test_result:: 1
@@ -193,10 +196,9 @@ def test_stop_volume_invalid(
 
     job_id = api.stop_volume(valid_cluster_id, volume_data)["job_id"]
     # TODO check correctly server response or etcd job status
-    api.wait_for_job_status(
-            job_id,
-            status="failed",
-            issue="https://github.com/Tendrl/tendrl-api/issues/33")
+    api.wait_for_job_status(job_id,
+                            status="failed",
+                            issue="https://github.com/Tendrl/tendrl-api/issues/33")
 
 
 def test_stop_volume_valid(
@@ -217,7 +219,8 @@ def test_stop_volume_valid(
 
         .. test_step:: 1
 
-                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterStopVolume``
+                Connect to Tendrl API via POST request
+                to ``APIURL/:cluster_id/GlusterStopVolume``
                 Where cluster_id is set to predefined value.
 
         .. test_result:: 1
@@ -265,7 +268,8 @@ def test_start_volume_invalid(
 
         .. test_step:: 1
 
-                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterStartVolume``
+                Connect to Tendrl API via POST request
+                to ``APIURL/:cluster_id/GlusterStartVolume``
                 Where cluster_id is set to predefined value.
 
         .. test_result:: 1
@@ -307,7 +311,8 @@ def test_start_volume_valid(
 
         .. test_step:: 1
 
-                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterStartVolume``
+                Connect to Tendrl API via POST request
+                to ``APIURL/:cluster_id/GlusterStartVolume``
                 Where cluster_id is set to predefined value.
 
         .. test_result:: 1
@@ -352,7 +357,8 @@ def test_delete_volume_invalid(
 
         .. test_step:: 1
 
-                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterDeleteVolume``
+                Connect to Tendrl API via POST request
+                to ``APIURL/:cluster_id/GlusterDeleteVolume``
                 Where cluster_id is set to predefined value.
 
         .. test_result:: 1
@@ -371,10 +377,9 @@ def test_delete_volume_invalid(
 
     job_id = api.delete_volume(valid_cluster_id, volume_data)["job_id"]
     # TODO check correctly server response or etcd job status
-    api.wait_for_job_status(
-            job_id,
-            status="failed",
-            issue="https://github.com/Tendrl/tendrl-api/issues/33")
+    api.wait_for_job_status(job_id,
+                            status="failed",
+                            issue="https://github.com/Tendrl/tendrl-api/issues/33")
 
 
 def test_delete_volume_valid(
@@ -395,7 +400,8 @@ def test_delete_volume_valid(
 
         .. test_step:: 1
 
-                Connect to Tendrl API via POST request to ``APIURL/:cluster_id/GlusterDeleteVolume``
+                Connect to Tendrl API via POST request
+                to ``APIURL/:cluster_id/GlusterDeleteVolume``
                 Where cluster_id is set to predefined value.
 
         .. test_result:: 1


### PR DESCRIPTION
This is first version of tests for pool CRUD valid and invalid. Please look at it. After this is merged I'll prepare version according our agreement from Monday.
Please consider again how long CRUD test for pool will be if it is one test function. Also will be great to split this test in Polarion which is in contradiction with my agreement with Martin B. about how to propagate pytest testcases to Polarion. Because it will be better to report it separately.
I still think that for CI we should use "reuse" entities because of performance.