### PR TITLE
fix inheritance for cluster import

### DIFF
--- a/usmqe/api/tendrlapi/cephapi.py
+++ b/usmqe/api/tendrlapi/cephapi.py
@@ -18,4 +18,4 @@ class TendrlApiCeph(TendrlApi):
             nodes (list): node list of cluster which will be imported
             asserts_in (dict): assert values for this call and this method
         """
-        super().import_cluster(nodes, "ceph", asserts_in)
+        return super().import_cluster(nodes, "ceph", asserts_in)

--- a/usmqe/api/tendrlapi/glusterapi.py
+++ b/usmqe/api/tendrlapi/glusterapi.py
@@ -19,7 +19,7 @@ class TendrlApiGluster(TendrlApi):
             nodes (list): node list of cluster which will be imported
             asserts_in (dict): assert values for this call and this method
         """
-        super().import_cluster(nodes, "gluster", asserts_in)
+        return super().import_cluster(nodes, "gluster", asserts_in)
 
 
 # TODO: https://github.com/Tendrl/api/issues/78


### PR DESCRIPTION
Fixes inheritance function for ceph and gluster.
Resolves https://github.com/Tendrl/usmqe-tests/issues/92