### PR TITLE
Enhance wait for job function

### DIFF
--- a/usmqe/api/tendrlapi/common.py
+++ b/usmqe/api/tendrlapi/common.py
@@ -153,13 +153,16 @@ class TendrlApi(ApiBase):
     def wait_for_job_status(
             self,
             job_id,
-            job_time=10000,
-            update_time=1000,
+            job_time=10800,
+            update_time=2700,
             status="finished",
             issue=None,
             sleep_time=10):
         """ Repeatedly check if status of job with provided id is in required state.
-        It is time bounded by job_time and each event is time bounded by update_time
+        It is time bounded by job_time and each event is time bounded by update_time.
+        According to default value for job_time the job is supposed to achieve desired
+        state in 3 hours (10800 seconds) and each event should not take more than
+        45 minutes (2700 seconds).
 
         Args:
             job_id: id provided by api request

--- a/usmqe/api/tendrlapi/common.py
+++ b/usmqe/api/tendrlapi/common.py
@@ -163,8 +163,8 @@ class TendrlApi(ApiBase):
 
         Args:
             job_id: id provided by api request
-            job_time: number of seconds in which the task must be in required state
-            update_time: number of seconds in which the event of the task must be done
+            job_time: job should achieve status in ``job_time`` seconds
+            update_time: event should be done in ``update_time`` seconds
             status: expected status of job that is checked
             issue: pytest issue message (usually github issue link)
             sleep_time: time in seconds between 2 job status function calls

--- a/usmqe/api/tendrlapi/common.py
+++ b/usmqe/api/tendrlapi/common.py
@@ -171,7 +171,7 @@ class TendrlApi(ApiBase):
         """
 
         start_time = datetime.datetime.now()
-        last_update = datetime.datetime.now()
+        last_update = start_time
         job_timeout = datetime.timedelta(0, job_time, 0)
         update_timeout = datetime.timedelta(0, update_time, 0)
         current_status = ""
@@ -187,6 +187,15 @@ class TendrlApi(ApiBase):
             if len(messages) > messages_count:
                 last_update = datetime.datetime.now()
                 messages_count = len(messages)
+        now = datetime.datetime.now()
+        pytest.check(
+            now - start_time <= job_timeout,
+            msg="Job shouldn't take longer then {},"
+            "it took: {}".format(job_timeout, now - start_time))
+        pytest.check(
+            now - start_time <= job_timeout,
+            msg="Job event shouldn't take longer then {},"
+            "last event took: {}".format(job_timeout, now - last_update))
         pytest.check(
             current_status == status,
             msg="Job status is {} and should be {}".format(

--- a/usmqe/api/tendrlapi/common.py
+++ b/usmqe/api/tendrlapi/common.py
@@ -171,20 +171,21 @@ class TendrlApi(ApiBase):
         """
 
         start_time = datetime.datetime.now()
+        last_update = datetime.datetime.now()
         job_timeout = datetime.timedelta(0, job_time, 0)
         update_timeout = datetime.timedelta(0, update_time, 0)
         current_status = ""
         messages_count = 0
         while current_status not in (status, "finished", "failed") and\
             datetime.datetime.now() - start_time <= job_timeout and\
-                datetime.datetime.now() - start_time <= update_timeout:
+                datetime.datetime.now() - last_update <= update_timeout:
             current_status = self.get_job_attribute(
                 job_id,
                 attribute="status")
             time.sleep(sleep_time)
             messages = self.get_job_messages(job_id)
             if len(messages) > messages_count:
-                update_timeout = datetime.timedelta(0, update_time, 0)
+                last_update = datetime.datetime.now()
                 messages_count = len(messages)
         pytest.check(
             current_status == status,

--- a/usmqe/api/tendrlapi/common.py
+++ b/usmqe/api/tendrlapi/common.py
@@ -172,28 +172,30 @@ class TendrlApi(ApiBase):
 
         start_time = datetime.datetime.now()
         last_update = start_time
-        job_timeout = datetime.timedelta(0, job_time, 0)
-        update_timeout = datetime.timedelta(0, update_time, 0)
+        job_timeout = datetime.timedelta(seconds=job_time)
+        update_timeout = datetime.timedelta(seconds=update_time)
         current_status = ""
         messages_count = 0
+        now = datetime.datetime.now()
         while current_status not in (status, "finished", "failed") and\
-            datetime.datetime.now() - start_time <= job_timeout and\
-                datetime.datetime.now() - last_update <= update_timeout:
+                now - start_time <= job_timeout and\
+                now - last_update <= update_timeout:
             current_status = self.get_job_attribute(
                 job_id,
                 attribute="status")
             time.sleep(sleep_time)
+            now = datetime.datetime.now()
+            LOGGER.debug("status: %s" % current_status)
             messages = self.get_job_messages(job_id)
             if len(messages) > messages_count:
                 last_update = datetime.datetime.now()
                 messages_count = len(messages)
-        now = datetime.datetime.now()
         pytest.check(
             now - start_time <= job_timeout,
             msg="Job shouldn't take longer then {},"
             "it took: {}".format(job_timeout, now - start_time))
         pytest.check(
-            now - start_time <= job_timeout,
+            now - last_update <= job_timeout,
             msg="Job event shouldn't take longer then {},"
             "last event took: {}".format(job_timeout, now - last_update))
         pytest.check(

--- a/usmqe/api/tendrlapi/common.py
+++ b/usmqe/api/tendrlapi/common.py
@@ -109,7 +109,7 @@ class TendrlApi(ApiBase):
         self._auth = auth
 
     def get_job_attribute(self, job_id, attribute="status", section=None):
-        """ Get attrubute from job specified by job_id.
+        """ Get attribute from job specified by job_id.
 
         Name:       "get_job_attribute",
         Method:     "GET",
@@ -130,6 +130,24 @@ class TendrlApi(ApiBase):
             return response.json()[section][attribute]
         else:
             return response.json()[attribute]
+
+    def get_job_messages(self, job_id):
+        """ Get messages from job specified by job_id.
+
+        Name:       "get_job_messages",
+        Method:     "GET",
+        Pattern     "jobs/:job_id:/messages",
+
+        Args:
+            job_id:     id of job
+        """
+        pattern = "jobs/{}/messages".format(job_id)
+        response = requests.get(
+            pytest.config.getini("usm_api_url") + pattern,
+            auth=self._auth,)
+        self.print_req_info(response)
+        self.check_response(response)
+        return response.json()
 
     def wait_for_job_status(
             self,

--- a/usmqe/api/tendrlapi/common.py
+++ b/usmqe/api/tendrlapi/common.py
@@ -134,10 +134,10 @@ class TendrlApi(ApiBase):
     def wait_for_job_status(
             self,
             job_id,
-            max_count=42,
+            max_count=100,
             status="finished",
             issue=None,
-            sleep_time=5):
+            sleep_time=10):
         """ Repeatedly check if status of job with provided id is in required state.
 
         Args:


### PR DESCRIPTION
Changes behaviour of `wait_for_job_status` function. Now is counter for wait reset when a new job message appears.

Resolves https://github.com/Tendrl/usmqe-tests/issues/91