### PR TITLE
Update task wait

### DIFF
--- a/usmqe/web/tendrl/import_cluster.py
+++ b/usmqe/web/tendrl/import_cluster.py
@@ -10,7 +10,6 @@ from webstr.selenium.ui.support import WebDriverUtils
 from usmqe.web.tendrl.mainpage.navpage.pages import NavMenuBars
 from usmqe.web.tendrl.mainpage.clusters.cluster_list.pages import\
     ClustersList, check_hosts
-from usmqe.web.tendrl.mainpage.tasks.pages import TaskDetails
 from usmqe.web.tendrl.mainpage.clusters.cluster.pages import ClusterMenu
 from usmqe.web.tendrl.task_wait import task_wait
 
@@ -18,14 +17,13 @@ from usmqe.web.tendrl.task_wait import task_wait
 IMPORT_TIMEOUT = 3600
 
 
-def import_cluster_wait(driver, import_task_details):
+def import_cluster_wait(driver):
     """
     wait till the import cluster task is finished
+    NOTE: it has to be on the page with task details
 
     Parameters:
         driver: selenium driver
-        import_task_details: webstr page object with import_cluster method
-                       landing_page-HomePage or cluster_list-ClustersMenu
         ttl (int): how long it waits till the tasks is finished
                    in seconds
 
@@ -33,7 +31,7 @@ def import_cluster_wait(driver, import_task_details):
         list of cluster objects
     """
     # Wait till the cluster is imported
-    task_wait(import_task_details, ttl=IMPORT_TIMEOUT)
+    task_wait(driver, ttl=IMPORT_TIMEOUT)
 
     NavMenuBars(driver).open_clusters(click_only=True)
 
@@ -68,9 +66,8 @@ def import_cluster(driver, import_page, clusters_nr=0, cluster_name=None,
 # TODO: Import specific cluster
     (cluster_ident, hosts_list) = import_page.import_cluster(
         cluster_ident=cluster_ident, name=cluster_name, hosts=hosts)
-    import_task_details = TaskDetails(driver)
 
-    cluster_list = import_cluster_wait(driver, import_task_details)
+    cluster_list = import_cluster_wait(driver)
 
     # Check that cluster is present in the list
     pytest.check(len(cluster_list) == clusters_nr + 1,

--- a/usmqe/web/tendrl/mainpage/tasks/models.py
+++ b/usmqe/web/tendrl/mainpage/tasks/models.py
@@ -3,7 +3,8 @@ Common page model for tasks.
 """
 
 
-from webstr.core import By, WebstrModel, PageElement, BaseWebElementHelper
+from webstr.core import By, WebstrModel, PageElement, BaseWebElementHelper,\
+    DynamicWebstrModel, RootPageElement, NameRootPageElement
 import webstr.patternfly.contentviews.models as contentviews
 import webstr.common.form.models as form
 
@@ -114,3 +115,42 @@ class TaskDetailsModel(WebstrModel):
         locator="//label[text()='Status:']/following-sibling::label/i")
     # TODO
     # messages, not working for now
+
+
+class TaskEventModel(DynamicWebstrModel):
+    """
+    An item (row) in a Tasks list.
+    """
+    _root = NameRootPageElement(
+        by=By.ID,
+        locator='log-list-group-item-%d')
+
+# Design: https://redhat.invisionapp.com/share/8N93NO7Q4
+    # missing status icon
+    # status_icon = StatusIcon(
+    #     by=By.XPATH,
+    #     locator="./div/i")
+    status_text = PageElement(
+        by=By.XPATH,
+        locator="./div[2]")
+    message = PageElement(
+        by=By.XPATH,
+        locator="./div[3]")
+    time = PageElement(
+        by=By.XPATH,
+        locator="./div[4]")
+
+
+class TaskEventsModel(WebstrModel):
+    """
+    Page model for list of tasks.
+    """
+    LIST_XPATH = '//*[contains(concat(" ", @class, " "), '\
+                 '" div-with-scroll-logs ")]'
+    _root = RootPageElement(By.XPATH, LIST_XPATH)
+    # header is a row too
+    rows = PageElement(
+        by=By.XPATH,
+        locator=LIST_XPATH + "//*[contains(concat(' ', @class, ' '),"
+        " ' list-group-item ')]",
+        as_list=True)

--- a/usmqe/web/tendrl/mainpage/tasks/pages.py
+++ b/usmqe/web/tendrl/mainpage/tasks/pages.py
@@ -7,6 +7,7 @@ from selenium.webdriver.common.keys import Keys
 
 from webstr.core import WebstrPage
 from webstr.patternfly.contentviews import pages as contentviews
+import webstr.common.containers.pages as containers
 
 import usmqe.web.tendrl.mainpage.tasks.models as m_tasks
 
@@ -163,3 +164,59 @@ class TaskDetails(WebstrPage):
 
     # TODO
     # work with messages
+
+
+class TaskEvent(containers.ContainerRowBase):
+    """
+    An item (row) in a Tasks list.
+    """
+    _model = m_tasks.TaskEventModel
+    _label = 'tasks event'
+    _required_elems = [
+        'status_text',
+        'message',
+        'time']
+
+    @property
+    def status_text(self):
+        """
+        find status
+
+        Returns:
+            status text
+        """
+        return self._model.status_text.text
+
+    @property
+    def message(self):
+        """
+        Returns:
+            event message
+        """
+        return self._model.message.text
+
+    @property
+    def time(self):
+        """
+        Returns:
+            event time
+        """
+        return self._model.time.text
+
+
+class TaskEvents(containers.ContainerBase):
+    """
+    Base page object for List of task events.
+    """
+    _model = m_tasks.TaskEventsModel
+    _label = 'task events'
+    _row_class = TasksItem
+    _required_elems = ['_root']
+
+    @property
+    def events_nr(self):
+        """
+        Returns:
+            number of events
+        """
+        return len(self._model.rows)

--- a/usmqe/web/tendrl/task_wait.py
+++ b/usmqe/web/tendrl/task_wait.py
@@ -44,10 +44,8 @@ def task_wait(driver, desired_state='Finished', ttl=600,
     # state of any task: New -> Processing -> Finished/Failed
     if desired_state == 'New':
         # initial task state, no need to wait for it
-        return
-    if desired_state != 'Processing' and\
-            desired_state != 'Finished' and\
-            desired_state != 'Failed':
+        raise TaskWaitException("Waiting for New doesn't make sense")
+    if desired_state not in ('Processing', 'Finished', 'Failed'):
         raise TaskWaitException('Unknown desired task state - {}'.format(
             desired_state))
 

--- a/usmqe/web/tendrl/task_wait.py
+++ b/usmqe/web/tendrl/task_wait.py
@@ -9,6 +9,8 @@ import time
 import datetime
 import pytest
 
+from usmqe.web.tendrl.mainpage.tasks.pages import TaskDetails, TaskEvents
+
 
 class TaskWaitException(Exception):
     """
@@ -16,26 +18,36 @@ class TaskWaitException(Exception):
     """
 
 
-def task_wait(task_details, desired_state='Finished', ttl=600):
+def task_wait(driver, desired_state='Finished', ttl=600,
+              update_time=600, sleep_time=5):
     """
     wait till the task has desired state
+    NOTE: it has to be on the page with task details
 
     Parameters:
-        task_details: webstr page object with task details
+        driver: selenium driver
         desired_state (str): task desired state
                              'New' -> 'Processing' -> 'Finished'/'Failed'
                              where 'New' is not accepted as desired state
         ttl (int): how long it waits till the tasks is finished
                    in seconds
+        update_time (int): how long it waits till the new message (event)
+                            is comming
+                           it's also the time how long the task could
+                            remain in 'New' state
+                           in seconds
+        sleep_time (int): sleep time between loops
     """
+    task_details = TaskDetails(driver)
+
     # Wait till the task has the correct state
     # state of any task: New -> Processing -> Finished/Failed
     if desired_state == 'New':
         # initial task state, no need to wait for it
         return
-    elif desired_state == 'Processing':
-        ttl = 4 * ttl
-    elif desired_state != 'Finished' and desired_state != 'Failed':
+    if desired_state != 'Processing' and\
+            desired_state != 'Finished' and\
+            desired_state != 'Failed':
         raise TaskWaitException('Unknown desired task state - {}'.format(
             desired_state))
 
@@ -43,40 +55,60 @@ def task_wait(task_details, desired_state='Finished', ttl=600):
     # No status icon presented till the end
     # status = task_details.status
     start_time = datetime.datetime.now()
-    timeout = datetime.timedelta(0, ttl, 0)
+    last_update = start_time
+    task_timeout = datetime.timedelta(seconds=ttl)
+    if desired_state == 'Processing':
+        # if processing use ttl for initial wait
+        # as there will be no other
+        update_timeout = task_timeout
+    else:
+        update_timeout = datetime.timedelta(seconds=update_time)
 
     while status_str != 'Processing' and\
             status_str != 'Finished' and\
             status_str != 'Failed' and\
-            datetime.datetime.now() - start_time <= timeout/4:
+            datetime.datetime.now() - start_time <= update_timeout:
         pytest.check(
             status_str == 'New',
             "Task status should be 'New', it is '{}'".format(status_str))
-        time.sleep(5)
+        time.sleep(sleep_time)
         status_str = task_details.status_text
 
     pytest.check(
-        datetime.datetime.now() - start_time <= timeout/4,
+        datetime.datetime.now() - start_time <= update_timeout,
         "Timeout check: The state of the task should not remain in "
-        "'New' state too long, longer than {} seconds".format(ttl/4),
+        "'New' state too long, longer than {} seconds".format(update_time),
         hard=True)
+
+    task_events = TaskEvents(driver)
+    events_nr = task_events.events_nr
 
     if desired_state == 'Processing':
         pytest.check(
-            status_str != 'Finished' and status_str != 'Failed',
+            status_str == desired_state,
             "Task status should be 'Processing', it is '{}'".format(
                 status_str))
         return
 
     while status_str == 'Processing' and\
-            datetime.datetime.now() - start_time <= timeout:
-        time.sleep(5)
+            datetime.datetime.now() - start_time <= task_timeout and\
+            datetime.datetime.now() - last_update <= update_timeout:
+        time.sleep(sleep_time)
         status_str = task_details.status_text
+        # check if there is a new event
+        if events_nr < task_events.events_nr:
+            last_update = datetime.datetime.now()
+            events_nr = task_events.events_nr
 
     pytest.check(
-        datetime.datetime.now() - start_time <= timeout,
+        datetime.datetime.now() - start_time <= task_timeout,
         "Timeout check: The state of the task should not remain in "
         "'Processing' state too long, longer than {} seconds".format(ttl),
+        hard=True)
+    pytest.check(
+        datetime.datetime.now() - last_update <= update_timeout,
+        "Timeout check: There should be an update every {} "
+        "seconds".format(update_time),
         hard=True)
 
     pytest.check(


### PR DESCRIPTION
This merge request involves:

* change of `import_cluster_wait()` function (mandatory argument `import_task_details` was removed)
* change of `task_wait()` function (mandatory `task_details` argument was removed, `update_time` and `sleep_time` introduced, moreover the waiting behavior was changed)
* new WebstrModel classess: `TaskEventModel` and `TaskEventsModel`
* new WebstrPage classess: `TaskEvent` and `TaskEvents`

The goal was to be more in compliance with similar method in api `wait_for_job_status`.