### PR TITLE
remove issue paramater for get_user method

### DIFF
--- a/usmqe/api/tendrlapi/user.py
+++ b/usmqe/api/tendrlapi/user.py
@@ -109,9 +109,7 @@ class ApiUser(TendrlApi):
             pytest.config.getini("usm_api_url") + pattern,
             auth=self._auth)
         self.print_req_info(request)
-        self.check_response(request, asserts_in,
-                            issue="https://bugzilla.redhat.com/show_bug.cgi?id=1457220,"
-                            "https://github.com/Tendrl/api/issues/140")
+        self.check_response(request, asserts_in)
 
         return request.json(encoding='unicode')
 


### PR DESCRIPTION
Issues related to this workaround were resolved:
https://github.com/Tendrl/api/issues/140
https://bugzilla.redhat.com/show_bug.cgi?id=1457220